### PR TITLE
KDV-176 Add detailed JSDoc and verified examples to neverthrow-r reference docs

### DIFF
--- a/packages/neverthrow-r/.claude/settings.local.json
+++ b/packages/neverthrow-r/.claude/settings.local.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "Bash(pnpm run *)"
+      "Bash(pnpm run *)",
+      "mcp__linear-server__get_issue"
     ]
   }
 }

--- a/packages/neverthrow-r/.gitignore
+++ b/packages/neverthrow-r/.gitignore
@@ -33,3 +33,6 @@ pnpm-debug.log*
 .vscode
 
 .turbo
+
+# extracted JSDoc @example fences (see scripts/check-examples.mjs)
+.examples-check/

--- a/packages/neverthrow-r/docs/reference-readme.md
+++ b/packages/neverthrow-r/docs/reference-readme.md
@@ -1,7 +1,3 @@
-**@konker.dev/neverthrow-r**
-
-***
-
 # `@konker.dev/neverthrow-r`
 
 A thin Reader-function layer over [neverthrow](https://github.com/supermacro/neverthrow). Every value is a function `(r: R) => Result<T, E>` (or its async sibling), so dependencies travel through a third **requirements** channel `R` alongside the usual `T` / `E` of `Result`.

--- a/packages/neverthrow-r/docs/reference/async/README.md
+++ b/packages/neverthrow-r/docs/reference/async/README.md
@@ -2,15 +2,40 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../README.md) / async
+[@konker.dev/neverthrow-r](../modules.md) / async
 
 # async
 
-Async operators over `ResultAsyncR`: `mapAsync`, `mapErrAsync`,
-`andThenAsync`, `orElseAsync`, `matchAsync`, `andTeeAsync`, `orTeeAsync`,
-`andThroughAsync`. Mirror the sync surface from `./sync`, suffixed with
-`Async` to avoid barrel collisions, and delegate to the corresponding
-neverthrow `ResultAsync` methods.
+Async combinators over `ResultAsyncR`, mirroring the sync surface from
+[sync](../sync/README.md) 1:1. Each combinator is the `Async`-suffixed sibling of its
+sync counterpart; semantics and type signatures match, lifted to
+`ResultAsyncR`.
+
+## Remarks
+
+Cross-link to the sync module for the full prose on each combinator. The
+docs here focus on the async-specific shape: each transformer accepts
+`Promise`-returning functions, and the operand is a `ResultAsyncR`.
+
+Reach for this module when the chain is already async (e.g. it started
+with okAsyncR or was promoted via [bridges](../bridges/README.md)). To enter the
+async track from a sync chain mid-pipeline, use [bridges](../bridges/README.md) instead.
+
+## Example
+
+```ts
+import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { andThenAsync, mapAsync } from '@konker.dev/neverthrow-r/async';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const program = pipe(
+  okAsyncR<number>(2),
+  mapAsync(async (n) => n + 1),
+  andThenAsync((n) => okAsyncR<string>(`got ${n}`)),
+);
+
+program(undefined); // ResultAsync resolving to Ok('got 3')
+```
 
 ## Functions
 

--- a/packages/neverthrow-r/docs/reference/async/functions/andTeeAsync.md
+++ b/packages/neverthrow-r/docs/reference/async/functions/andTeeAsync.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [async](../README.md) / andTeeAsync
+[@konker.dev/neverthrow-r](../../modules.md) / [async](../README.md) / andTeeAsync
 
 # Function: andTeeAsync()
 
 > **andTeeAsync**\<`T`\>(`f`): \<`R`, `E`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `T`, `E`\>
 
-Defined in: [async.ts:44](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L44)
+Defined in: [async.ts:171](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L171)
+
+Async variant of andTee.
 
 ## Type Parameters
 
@@ -45,3 +47,17 @@ Defined in: [async.ts:44](https://github.com/konker/konker.dev/blob/main/package
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `T`, `E`\>
+
+## Example
+
+```ts
+import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { andTeeAsync } from '@konker.dev/neverthrow-r/async';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const traced = pipe(okAsyncR<number>(2), andTeeAsync((n) => console.log(n)));
+```
+
+## See
+
+andTee

--- a/packages/neverthrow-r/docs/reference/async/functions/andThenAsync.md
+++ b/packages/neverthrow-r/docs/reference/async/functions/andThenAsync.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [async](../README.md) / andThenAsync
+[@konker.dev/neverthrow-r](../../modules.md) / [async](../README.md) / andThenAsync
 
 # Function: andThenAsync()
 
 > **andThenAsync**\<`A`, `R2`, `B`, `E2`\>(`f`): \<`R1`, `E1`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, `B`, `E2` \| `E1`\>
 
-Defined in: [async.ts:26](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L26)
+Defined in: [async.ts:100](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L100)
+
+Async variant of andThen. The continuation returns a
+`ResultAsyncR`; its requirements intersect into the chain.
 
 ## Type Parameters
 
@@ -57,3 +60,20 @@ Defined in: [async.ts:26](https://github.com/konker/konker.dev/blob/main/package
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, `B`, `E2` \| `E1`\>
+
+## Example
+
+```ts
+import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { andThenAsync } from '@konker.dev/neverthrow-r/async';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const program = pipe(
+  okAsyncR<number>(2),
+  andThenAsync((n) => okAsyncR<string>(`got ${n}`)),
+);
+```
+
+## See
+
+andThen

--- a/packages/neverthrow-r/docs/reference/async/functions/andThroughAsync.md
+++ b/packages/neverthrow-r/docs/reference/async/functions/andThroughAsync.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [async](../README.md) / andThroughAsync
+[@konker.dev/neverthrow-r](../../modules.md) / [async](../README.md) / andThroughAsync
 
 # Function: andThroughAsync()
 
 > **andThroughAsync**\<`T`, `R2`, `F`\>(`f`): \<`R1`, `E`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, `T`, `F` \| `E`\>
 
-Defined in: [async.ts:56](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L56)
+Defined in: [async.ts:216](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L216)
+
+Async variant of andThrough.
 
 ## Type Parameters
 
@@ -53,3 +55,22 @@ Defined in: [async.ts:56](https://github.com/konker/konker.dev/blob/main/package
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, `T`, `F` \| `E`\>
+
+## Example
+
+```ts
+import { errAsyncR, okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { andThroughAsync } from '@konker.dev/neverthrow-r/async';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const validated = pipe(
+  okAsyncR<number>(2),
+  andThroughAsync((n) =>
+    n > 0 ? okAsyncR<unknown>(undefined) : errAsyncR<string>('non-positive'),
+  ),
+);
+```
+
+## See
+
+andThrough

--- a/packages/neverthrow-r/docs/reference/async/functions/mapAsync.md
+++ b/packages/neverthrow-r/docs/reference/async/functions/mapAsync.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [async](../README.md) / mapAsync
+[@konker.dev/neverthrow-r](../../modules.md) / [async](../README.md) / mapAsync
 
 # Function: mapAsync()
 
 > **mapAsync**\<`A`, `B`\>(`f`): \<`R`, `E`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `B`, `E`\>
 
-Defined in: [async.ts:14](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L14)
+Defined in: [async.ts:52](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L52)
+
+Async variant of map. Accepts a sync- or `Promise`-returning
+transform.
 
 ## Type Parameters
 
@@ -49,3 +52,17 @@ Defined in: [async.ts:14](https://github.com/konker/konker.dev/blob/main/package
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `B`, `E`\>
+
+## Example
+
+```ts
+import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { mapAsync } from '@konker.dev/neverthrow-r/async';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const doubled = pipe(okAsyncR<number>(2), mapAsync(async (n) => n * 2));
+```
+
+## See
+
+map

--- a/packages/neverthrow-r/docs/reference/async/functions/mapErrAsync.md
+++ b/packages/neverthrow-r/docs/reference/async/functions/mapErrAsync.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [async](../README.md) / mapErrAsync
+[@konker.dev/neverthrow-r](../../modules.md) / [async](../README.md) / mapErrAsync
 
 # Function: mapErrAsync()
 
 > **mapErrAsync**\<`E`, `F`\>(`f`): \<`R`, `T`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `T`, `F`\>
 
-Defined in: [async.ts:20](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L20)
+Defined in: [async.ts:76](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L76)
+
+Async variant of mapErr. Accepts a sync- or `Promise`-returning
+transform.
 
 ## Type Parameters
 
@@ -49,3 +52,20 @@ Defined in: [async.ts:20](https://github.com/konker/konker.dev/blob/main/package
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `T`, `F`\>
+
+## Example
+
+```ts
+import { errAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { mapErrAsync } from '@konker.dev/neverthrow-r/async';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const wrapped = pipe(
+  errAsyncR<string>('boom'),
+  mapErrAsync(async (msg) => ({ tag: 'fail' as const, msg })),
+);
+```
+
+## See
+
+mapErr

--- a/packages/neverthrow-r/docs/reference/async/functions/matchAsync.md
+++ b/packages/neverthrow-r/docs/reference/async/functions/matchAsync.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [async](../README.md) / matchAsync
+[@konker.dev/neverthrow-r](../../modules.md) / [async](../README.md) / matchAsync
 
 # Function: matchAsync()
 
 > **matchAsync**\<`T`, `E`, `A`, `B`\>(`okFn`, `errFn`): \<`R`\>(`rr`) => (`r`) => `Promise`\<`A` \| `B`\>
 
-Defined in: [async.ts:38](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L38)
+Defined in: [async.ts:151](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L151)
+
+Async variant of match. Returns a function from environment to a
+`Promise` of the matched value.
 
 ## Type Parameters
 
@@ -67,3 +70,24 @@ Defined in: [async.ts:38](https://github.com/konker/konker.dev/blob/main/package
 #### Returns
 
 `Promise`\<`A` \| `B`\>
+
+## Example
+
+```ts
+import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { matchAsync } from '@konker.dev/neverthrow-r/async';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const rendered = pipe(
+  okAsyncR<number>(42),
+  matchAsync(
+    (n) => `got ${n}`,
+    (e: never) => `error: ${String(e)}`,
+  ),
+);
+// rendered(undefined) is Promise<string>
+```
+
+## See
+
+match

--- a/packages/neverthrow-r/docs/reference/async/functions/orElseAsync.md
+++ b/packages/neverthrow-r/docs/reference/async/functions/orElseAsync.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [async](../README.md) / orElseAsync
+[@konker.dev/neverthrow-r](../../modules.md) / [async](../README.md) / orElseAsync
 
 # Function: orElseAsync()
 
 > **orElseAsync**\<`E`, `R2`, `U`, `F`\>(`f`): \<`R1`, `T`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, `U` \| `T`, `F`\>
 
-Defined in: [async.ts:32](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L32)
+Defined in: [async.ts:123](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L123)
+
+Async variant of orElse. The recovery returns a `ResultAsyncR`.
 
 ## Type Parameters
 
@@ -57,3 +59,20 @@ Defined in: [async.ts:32](https://github.com/konker/konker.dev/blob/main/package
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, `U` \| `T`, `F`\>
+
+## Example
+
+```ts
+import { errAsyncR, okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { orElseAsync } from '@konker.dev/neverthrow-r/async';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const withFallback = pipe(
+  errAsyncR<string, number>('boom'),
+  orElseAsync(() => okAsyncR<number>(0)),
+);
+```
+
+## See
+
+orElse

--- a/packages/neverthrow-r/docs/reference/async/functions/orTeeAsync.md
+++ b/packages/neverthrow-r/docs/reference/async/functions/orTeeAsync.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [async](../README.md) / orTeeAsync
+[@konker.dev/neverthrow-r](../../modules.md) / [async](../README.md) / orTeeAsync
 
 # Function: orTeeAsync()
 
 > **orTeeAsync**\<`E`\>(`f`): \<`R`, `T`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `T`, `E`\>
 
-Defined in: [async.ts:50](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L50)
+Defined in: [async.ts:191](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/async.ts#L191)
+
+Async variant of orTee.
 
 ## Type Parameters
 
@@ -45,3 +47,17 @@ Defined in: [async.ts:50](https://github.com/konker/konker.dev/blob/main/package
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `T`, `E`\>
+
+## Example
+
+```ts
+import { errAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { orTeeAsync } from '@konker.dev/neverthrow-r/async';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const logged = pipe(errAsyncR<string>('boom'), orTeeAsync((e) => console.error(e)));
+```
+
+## See
+
+orTee

--- a/packages/neverthrow-r/docs/reference/bridges/README.md
+++ b/packages/neverthrow-r/docs/reference/bridges/README.md
@@ -2,14 +2,43 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../README.md) / bridges
+[@konker.dev/neverthrow-r](../modules.md) / bridges
 
 # bridges
 
-Sync→async bridge operators that take a `ResultR` and return a
-`ResultAsyncR`: `asyncMap`, `asyncAndThen`, `asyncAndThrough`. They follow
-the same `R1 & R2` intersection rule as the pure sync/async operators,
-promoting the chain to the async track.
+Sync→async bridge operators: take a `ResultR` and return a `ResultAsyncR`,
+promoting the chain onto the async track mid-pipeline.
+
+## Remarks
+
+Reach for this module when a chain that starts synchronously needs to
+await — typically an I/O call partway through. Three flavours, mirroring
+the corresponding sync combinators but lifting the operand into
+`ResultAsyncR`:
+
+- [asyncMap](functions/asyncMap.md) — promote via a `Promise`-returning transform.
+- [asyncAndThen](functions/asyncAndThen.md) — promote via a `ResultAsyncR`-returning step.
+- [asyncAndThrough](functions/asyncAndThrough.md) — promote via a fallible async tee.
+
+Every step *after* the bridge must come from [async](../async/README.md) (the
+`*Async`-suffixed combinators); there is no async→sync bridge.
+
+## Example
+
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { mapAsync } from '@konker.dev/neverthrow-r/async';
+import { asyncMap } from '@konker.dev/neverthrow-r/bridges';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const program = pipe(
+  okR<number>(2),
+  asyncMap(async (n) => n + 1),   // sync → async here
+  mapAsync(async (n) => n * 10),  // continue async
+);
+
+program(undefined); // ResultAsync resolving to Ok(30)
+```
 
 ## Functions
 

--- a/packages/neverthrow-r/docs/reference/bridges/functions/asyncAndThen.md
+++ b/packages/neverthrow-r/docs/reference/bridges/functions/asyncAndThen.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [bridges](../README.md) / asyncAndThen
+[@konker.dev/neverthrow-r](../../modules.md) / [bridges](../README.md) / asyncAndThen
 
 # Function: asyncAndThen()
 
 > **asyncAndThen**\<`A`, `R2`, `B`, `E2`\>(`f`): \<`R1`, `E1`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, `B`, `E2` \| `E1`\>
 
-Defined in: [bridges.ts:19](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/bridges.ts#L19)
+Defined in: [bridges.ts:105](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/bridges.ts#L105)
+
+Promotes a `ResultR` to a `ResultAsyncR` by chaining a
+`ResultAsyncR`-returning step.
 
 ## Type Parameters
 
@@ -16,23 +19,33 @@ Defined in: [bridges.ts:19](https://github.com/konker/konker.dev/blob/main/packa
 
 `A`
 
+The previous step's success type.
+
 ### R2
 
 `R2`
+
+The continuation's requirements.
 
 ### B
 
 `B`
 
+The continuation's success type.
+
 ### E2
 
 `E2`
+
+The continuation's error type.
 
 ## Parameters
 
 ### f
 
 (`a`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R2`, `B`, `E2`\>
+
+Function from the previous success value to a `ResultAsyncR`.
 
 ## Returns
 
@@ -57,3 +70,29 @@ Defined in: [bridges.ts:19](https://github.com/konker/konker.dev/blob/main/packa
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, `B`, `E2` \| `E1`\>
+
+## Remarks
+
+Sync→async sibling of andThen. The continuation's requirements
+`R2` are intersected (`R1 & R2`); its error type `E2` is unioned
+(`E1 | E2`).
+
+## Example
+
+```ts
+import { okAsyncR, okR } from '@konker.dev/neverthrow-r/constructors';
+import { asyncAndThen } from '@konker.dev/neverthrow-r/bridges';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const program = pipe(
+  okR<number>(2),
+  asyncAndThen((n) => okAsyncR<string>(`got ${n}`)),
+);
+
+program(undefined); // ResultAsync resolving to Ok('got 2')
+```
+
+## See
+
+ - andThen
+ - andThenAsync

--- a/packages/neverthrow-r/docs/reference/bridges/functions/asyncAndThrough.md
+++ b/packages/neverthrow-r/docs/reference/bridges/functions/asyncAndThrough.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [bridges](../README.md) / asyncAndThrough
+[@konker.dev/neverthrow-r](../../modules.md) / [bridges](../README.md) / asyncAndThrough
 
 # Function: asyncAndThrough()
 
 > **asyncAndThrough**\<`T`, `R2`, `F`\>(`f`): \<`R1`, `E`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, `T`, `F` \| `E`\>
 
-Defined in: [bridges.ts:25](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/bridges.ts#L25)
+Defined in: [bridges.ts:144](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/bridges.ts#L144)
+
+Promotes a `ResultR` to a `ResultAsyncR` via a fallible async tee that
+propagates the *original* success value.
 
 ## Type Parameters
 
@@ -16,19 +19,28 @@ Defined in: [bridges.ts:25](https://github.com/konker/konker.dev/blob/main/packa
 
 `T`
 
+The success type (preserved through the step on success).
+
 ### R2
 
 `R2`
 
+The tee's requirements.
+
 ### F
 
 `F`
+
+The tee's error type.
 
 ## Parameters
 
 ### f
 
 (`t`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R2`, `unknown`, `F`\>
+
+Function from the success value to a `ResultAsyncR` whose value
+  is ignored on success.
 
 ## Returns
 
@@ -53,3 +65,29 @@ Defined in: [bridges.ts:25](https://github.com/konker/konker.dev/blob/main/packa
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, `T`, `F` \| `E`\>
+
+## Remarks
+
+Sync→async sibling of andThrough. The tee step is itself a
+`ResultAsyncR` that can fail; on success its value is discarded and the
+chain continues with the original success value.
+
+## Example
+
+```ts
+import { okAsyncR, okR } from '@konker.dev/neverthrow-r/constructors';
+import { asyncAndThrough } from '@konker.dev/neverthrow-r/bridges';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const program = pipe(
+  okR<number>(2),
+  asyncAndThrough((n) => okAsyncR<unknown>(`logged ${n}`)),
+);
+
+program(undefined); // ResultAsync resolving to Ok(2)
+```
+
+## See
+
+ - andThrough
+ - andThroughAsync

--- a/packages/neverthrow-r/docs/reference/bridges/functions/asyncMap.md
+++ b/packages/neverthrow-r/docs/reference/bridges/functions/asyncMap.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [bridges](../README.md) / asyncMap
+[@konker.dev/neverthrow-r](../../modules.md) / [bridges](../README.md) / asyncMap
 
 # Function: asyncMap()
 
 > **asyncMap**\<`A`, `B`\>(`f`): \<`R`, `E`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `B`, `E`\>
 
-Defined in: [bridges.ts:13](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/bridges.ts#L13)
+Defined in: [bridges.ts:66](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/bridges.ts#L66)
+
+Promotes a `ResultR` to a `ResultAsyncR` by applying a `Promise`-returning
+transform to the success value.
 
 ## Type Parameters
 
@@ -16,15 +19,21 @@ Defined in: [bridges.ts:13](https://github.com/konker/konker.dev/blob/main/packa
 
 `A`
 
+The input success type.
+
 ### B
 
 `B`
+
+The output success type.
 
 ## Parameters
 
 ### f
 
 (`a`) => `Promise`\<`B`\>
+
+`Promise`-returning transform from `A` to `B`.
 
 ## Returns
 
@@ -49,3 +58,24 @@ Defined in: [bridges.ts:13](https://github.com/konker/konker.dev/blob/main/packa
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `B`, `E`\>
+
+## Remarks
+
+The sync→async sibling of map. After this step the chain is async;
+follow with mapAsync, andThenAsync, etc.
+
+## Example
+
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { asyncMap } from '@konker.dev/neverthrow-r/bridges';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const program = pipe(okR<number>(2), asyncMap(async (n) => n * 2));
+program(undefined); // ResultAsync resolving to Ok(4)
+```
+
+## See
+
+ - map
+ - mapAsync

--- a/packages/neverthrow-r/docs/reference/constructors/README.md
+++ b/packages/neverthrow-r/docs/reference/constructors/README.md
@@ -2,14 +2,44 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../README.md) / constructors
+[@konker.dev/neverthrow-r](../modules.md) / constructors
 
 # constructors
 
-Constructors and lifters that produce `ResultR` / `ResultAsyncR` values:
-`okR`, `errR`, `okAsyncR`, `errAsyncR` for plain values; `fromResult` and
-`fromResultAsync` for lifting existing neverthrow values; `asks` and `ask`
-for building a `ResultR` directly from the environment.
+Entry points for building `ResultR` / `ResultAsyncR` values from scratch or
+from existing `neverthrow` values. Use these where a pipeline starts.
+
+## Remarks
+
+- [okR](functions/okR.md) / [errR](functions/errR.md) / [okAsyncR](functions/okAsyncR.md) / [errAsyncR](functions/errAsyncR.md) — lift a
+  plain value (or error) into a `ResultR` / `ResultAsyncR` with no
+  requirements (`R = unknown`).
+- [fromResult](functions/fromResult.md) / [fromResultAsync](functions/fromResultAsync.md) — lift an existing neverthrow
+  `Result` / `ResultAsync` into the `R`-channel layer with no requirements.
+- [asks](functions/asks.md) / [ask](functions/ask.md) — build a `ResultR` whose only effect is to
+  read from the environment, declaring `R` in the process.
+
+Any non-trivial requirements (a database handle, a clock, …) are introduced
+with `asks`; the rest of the pipeline picks them up via intersection in
+`andThen`-style operators.
+
+## Example
+
+```ts
+import { asks, okR } from '@konker.dev/neverthrow-r/constructors';
+import { andThen, map } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+type Clock = { now: () => Date };
+
+const year = asks((r: Clock) => r.now().getFullYear());
+
+const program = pipe(
+  okR<number>(2024),
+  map((n) => n + 1),
+  andThen(() => year),
+);
+```
 
 ## Functions
 

--- a/packages/neverthrow-r/docs/reference/constructors/functions/ask.md
+++ b/packages/neverthrow-r/docs/reference/constructors/functions/ask.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [constructors](../README.md) / ask
+[@konker.dev/neverthrow-r](../../modules.md) / [constructors](../README.md) / ask
 
 # Function: ask()
 
 > **ask**\<`R`\>(): [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `R`, `never`\>
 
-Defined in: [constructors.ts:50](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L50)
+Defined in: [constructors.ts:245](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L245)
+
+Reads the entire environment as the success value.
 
 ## Type Parameters
 
@@ -16,6 +18,29 @@ Defined in: [constructors.ts:50](https://github.com/konker/konker.dev/blob/main/
 
 `R`
 
+The requirements (environment), surfaced as the success type.
+
 ## Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `R`, `never`\>
+
+## Remarks
+
+Specialisation of [asks](asks.md) with the identity function. Most useful when
+a step wants the whole environment passed downstream — e.g. to forward it
+into a sub-pipeline.
+
+## Example
+
+```ts
+import { ask } from '@konker.dev/neverthrow-r/constructors';
+
+type Config = { multiplier: number };
+
+const env = ask<Config>();
+env({ multiplier: 10 }); // Ok({ multiplier: 10 })
+```
+
+## See
+
+[asks](asks.md)

--- a/packages/neverthrow-r/docs/reference/constructors/functions/asks.md
+++ b/packages/neverthrow-r/docs/reference/constructors/functions/asks.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [constructors](../README.md) / asks
+[@konker.dev/neverthrow-r](../../modules.md) / [constructors](../README.md) / asks
 
 # Function: asks()
 
 > **asks**\<`R`, `A`\>(`f`): [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `A`, `never`\>
 
-Defined in: [constructors.ts:46](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L46)
+Defined in: [constructors.ts:219](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L219)
+
+Builds a `ResultR` whose value is computed from the environment. This is
+how requirements are *introduced* into a chain.
 
 ## Type Parameters
 
@@ -16,9 +19,13 @@ Defined in: [constructors.ts:46](https://github.com/konker/konker.dev/blob/main/
 
 `R`
 
+The requirements (environment) read from.
+
 ### A
 
 `A`
+
+The value computed from the environment.
 
 ## Parameters
 
@@ -26,6 +33,33 @@ Defined in: [constructors.ts:46](https://github.com/konker/konker.dev/blob/main/
 
 (`r`) => `A`
 
+A pure function from environment to value.
+
 ## Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `A`, `never`\>
+
+## Remarks
+
+`asks(f)` is equivalent to `(r) => ok(f(r))`. The argument's parameter type
+fixes the `R` channel for the rest of the pipeline; downstream operators
+intersect any further requirements.
+
+Use this when a step depends on something in the environment (a config
+value, a service handle, the current time). For just reading the entire
+environment unchanged, see [ask](ask.md).
+
+## Example
+
+```ts
+import { asks } from '@konker.dev/neverthrow-r/constructors';
+
+type Config = { multiplier: number };
+
+const multiplier = asks((r: Config) => r.multiplier);
+multiplier({ multiplier: 10 }); // Ok(10)
+```
+
+## See
+
+[ask](ask.md)

--- a/packages/neverthrow-r/docs/reference/constructors/functions/errAsyncR.md
+++ b/packages/neverthrow-r/docs/reference/constructors/functions/errAsyncR.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [constructors](../README.md) / errAsyncR
+[@konker.dev/neverthrow-r](../../modules.md) / [constructors](../README.md) / errAsyncR
 
 # Function: errAsyncR()
 
 > **errAsyncR**\<`E`, `T`\>(`error`): [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`unknown`, `T`, `E`\>
 
-Defined in: [constructors.ts:31](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L31)
+Defined in: [constructors.ts:133](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L133)
+
+Async sibling of [errR](errR.md): lifts a plain error value into a
+`ResultAsyncR` with no requirements.
 
 ## Type Parameters
 
@@ -29,3 +32,16 @@ Defined in: [constructors.ts:31](https://github.com/konker/konker.dev/blob/main/
 ## Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`unknown`, `T`, `E`\>
+
+## Example
+
+```ts
+import { errAsyncR } from '@konker.dev/neverthrow-r/constructors';
+
+const fail = errAsyncR<string>('boom');
+fail(undefined); // ResultAsync resolving to Err('boom')
+```
+
+## See
+
+[errR](errR.md)

--- a/packages/neverthrow-r/docs/reference/constructors/functions/errR.md
+++ b/packages/neverthrow-r/docs/reference/constructors/functions/errR.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [constructors](../README.md) / errR
+[@konker.dev/neverthrow-r](../../modules.md) / [constructors](../README.md) / errR
 
 # Function: errR()
 
 > **errR**\<`E`, `T`\>(`error`): [`ResultR`](../../types/type-aliases/ResultR.md)\<`unknown`, `T`, `E`\>
 
-Defined in: [constructors.ts:21](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L21)
+Defined in: [constructors.ts:95](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L95)
+
+Lifts a plain error value into a `ResultR` with no requirements.
 
 ## Type Parameters
 
@@ -16,9 +18,14 @@ Defined in: [constructors.ts:21](https://github.com/konker/konker.dev/blob/main/
 
 `E`
 
+The error type.
+
 ### T
 
 `T` = `never`
+
+The success type (defaults to `never` since this always
+  fails).
 
 ## Parameters
 
@@ -26,6 +33,22 @@ Defined in: [constructors.ts:21](https://github.com/konker/konker.dev/blob/main/
 
 `E`
 
+The error value to wrap in an `Err`.
+
 ## Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`unknown`, `T`, `E`\>
+
+## Example
+
+```ts
+import { errR } from '@konker.dev/neverthrow-r/constructors';
+
+const fail = errR<string>('boom');
+fail(undefined); // Err('boom')
+```
+
+## See
+
+ - [okR](okR.md)
+ - [errAsyncR](errAsyncR.md)

--- a/packages/neverthrow-r/docs/reference/constructors/functions/fromResult.md
+++ b/packages/neverthrow-r/docs/reference/constructors/functions/fromResult.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [constructors](../README.md) / fromResult
+[@konker.dev/neverthrow-r](../../modules.md) / [constructors](../README.md) / fromResult
 
 # Function: fromResult()
 
 > **fromResult**\<`T`, `E`\>(`r`): [`ResultR`](../../types/type-aliases/ResultR.md)\<`unknown`, `T`, `E`\>
 
-Defined in: [constructors.ts:36](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L36)
+Defined in: [constructors.ts:163](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L163)
+
+Lifts an existing neverthrow `Result<T, E>` into a `ResultR<unknown, T, E>`.
 
 ## Type Parameters
 
@@ -16,9 +18,13 @@ Defined in: [constructors.ts:36](https://github.com/konker/konker.dev/blob/main/
 
 `T`
 
+The success type.
+
 ### E
 
 `E`
+
+The error type.
 
 ## Parameters
 
@@ -26,6 +32,29 @@ Defined in: [constructors.ts:36](https://github.com/konker/konker.dev/blob/main/
 
 `Result`\<`T`, `E`\>
 
+The existing `Result` to lift.
+
 ## Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`unknown`, `T`, `E`\>
+
+## Remarks
+
+Useful at the seam where existing neverthrow-using code is being adapted
+into a pipeline that wants the `R` channel — wrap the legacy value once and
+compose normally thereafter.
+
+## Example
+
+```ts
+import { ok } from 'neverthrow';
+import { fromResult } from '@konker.dev/neverthrow-r/constructors';
+
+const existing = ok<number, string>(42);
+const lifted = fromResult(existing);
+lifted(undefined); // Ok(42)
+```
+
+## See
+
+[fromResultAsync](fromResultAsync.md)

--- a/packages/neverthrow-r/docs/reference/constructors/functions/fromResultAsync.md
+++ b/packages/neverthrow-r/docs/reference/constructors/functions/fromResultAsync.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [constructors](../README.md) / fromResultAsync
+[@konker.dev/neverthrow-r](../../modules.md) / [constructors](../README.md) / fromResultAsync
 
 # Function: fromResultAsync()
 
 > **fromResultAsync**\<`T`, `E`\>(`ra`): [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`unknown`, `T`, `E`\>
 
-Defined in: [constructors.ts:41](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L41)
+Defined in: [constructors.ts:184](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L184)
+
+Async sibling of [fromResult](fromResult.md): lifts an existing `ResultAsync<T, E>`
+into a `ResultAsyncR<unknown, T, E>`.
 
 ## Type Parameters
 
@@ -29,3 +32,18 @@ Defined in: [constructors.ts:41](https://github.com/konker/konker.dev/blob/main/
 ## Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`unknown`, `T`, `E`\>
+
+## Example
+
+```ts
+import { okAsync } from 'neverthrow';
+import { fromResultAsync } from '@konker.dev/neverthrow-r/constructors';
+
+const existing = okAsync<number, string>(42);
+const lifted = fromResultAsync(existing);
+lifted(undefined); // ResultAsync resolving to Ok(42)
+```
+
+## See
+
+[fromResult](fromResult.md)

--- a/packages/neverthrow-r/docs/reference/constructors/functions/okAsyncR.md
+++ b/packages/neverthrow-r/docs/reference/constructors/functions/okAsyncR.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [constructors](../README.md) / okAsyncR
+[@konker.dev/neverthrow-r](../../modules.md) / [constructors](../README.md) / okAsyncR
 
 # Function: okAsyncR()
 
 > **okAsyncR**\<`T`, `E`\>(`value`): [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`unknown`, `T`, `E`\>
 
-Defined in: [constructors.ts:26](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L26)
+Defined in: [constructors.ts:114](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L114)
+
+Async sibling of [okR](okR.md): lifts a plain success value into a
+`ResultAsyncR` with no requirements.
 
 ## Type Parameters
 
@@ -29,3 +32,16 @@ Defined in: [constructors.ts:26](https://github.com/konker/konker.dev/blob/main/
 ## Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`unknown`, `T`, `E`\>
+
+## Example
+
+```ts
+import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+
+const program = okAsyncR<number>(2);
+program(undefined); // ResultAsync resolving to Ok(2)
+```
+
+## See
+
+[okR](okR.md)

--- a/packages/neverthrow-r/docs/reference/constructors/functions/okR.md
+++ b/packages/neverthrow-r/docs/reference/constructors/functions/okR.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [constructors](../README.md) / okR
+[@konker.dev/neverthrow-r](../../modules.md) / [constructors](../README.md) / okR
 
 # Function: okR()
 
 > **okR**\<`T`, `E`\>(`value`): [`ResultR`](../../types/type-aliases/ResultR.md)\<`unknown`, `T`, `E`\>
 
-Defined in: [constructors.ts:16](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L16)
+Defined in: [constructors.ts:70](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/constructors.ts#L70)
+
+Lifts a plain success value into a `ResultR` with no requirements.
 
 ## Type Parameters
 
@@ -16,9 +18,14 @@ Defined in: [constructors.ts:16](https://github.com/konker/konker.dev/blob/main/
 
 `T`
 
+The success type.
+
 ### E
 
 `E` = `never`
+
+The error type (defaults to `never` since this always
+  succeeds).
 
 ## Parameters
 
@@ -26,6 +33,30 @@ Defined in: [constructors.ts:16](https://github.com/konker/konker.dev/blob/main/
 
 `T`
 
+The value to wrap in an `Ok`.
+
 ## Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`unknown`, `T`, `E`\>
+
+A `ResultR<unknown, T, E>` that ignores its environment and yields
+  `Ok(value)`.
+
+## Remarks
+
+Equivalent to `() => ok(value)`. The `R` parameter defaults to `unknown`
+because the constructor doesn't read from the environment.
+
+## Example
+
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+
+const two = okR<number>(2);
+two(undefined); // Ok(2)
+```
+
+## See
+
+ - [errR](errR.md)
+ - [okAsyncR](okAsyncR.md)

--- a/packages/neverthrow-r/docs/reference/do/README.md
+++ b/packages/neverthrow-r/docs/reference/do/README.md
@@ -2,15 +2,45 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../README.md) / do
+[@konker.dev/neverthrow-r](../modules.md) / do
 
 # do
 
-`bind`-style do-notation for sequentially composing chains that accumulate
-intermediate values into a record-shaped "scope" while threading `R`.
-`doR` / `doAsyncR` seed an empty scope; `bindR` / `bindAsyncR` add a named
-field, intersect the step's `R2` into the chain's requirements, and union
-its error type. Ergonomic replacement for a generator-based `safeTry`.
+Do-notation for `ResultR` / `ResultAsyncR`: chain steps that each bind a
+value into a named scope, with the scope record carried through the chain
+as the success type.
+
+## Remarks
+
+Two pairs of helpers:
+
+- [doR](functions/doR.md) / [doAsyncR](functions/doAsyncR.md) — seed a chain with an empty scope `{}`.
+- [bindR](functions/bindR.md) / [bindAsyncR](functions/bindAsyncR.md) — add a named field by running a step
+  that depends on the current scope, then attaching its result under a key.
+
+Use this in place of nested andThen when several intermediate
+values are needed downstream. Requirements `R` intersect across steps; the
+error channel unions; the success record grows with each `bind*`.
+
+## Example
+
+```ts
+import { asks, okR } from '@konker.dev/neverthrow-r/constructors';
+import { bindR, doR } from '@konker.dev/neverthrow-r/do';
+import { map } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+type Config = { greeting: string };
+
+const program = pipe(
+  doR(),
+  bindR('name', () => okR<string>('world')),
+  bindR('greeting', () => asks((r: Config) => r.greeting)),
+  map(({ greeting, name }) => `${greeting}, ${name}!`),
+);
+
+program({ greeting: 'hello' }); // Ok('hello, world!')
+```
 
 ## Functions
 

--- a/packages/neverthrow-r/docs/reference/do/functions/bindAsyncR.md
+++ b/packages/neverthrow-r/docs/reference/do/functions/bindAsyncR.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [do](../README.md) / bindAsyncR
+[@konker.dev/neverthrow-r](../../modules.md) / [do](../README.md) / bindAsyncR
 
 # Function: bindAsyncR()
 
 > **bindAsyncR**\<`N`, `S`, `R2`, `A`, `E2`\>(`name`, `f`): \<`R1`, `E1`\>(`rr`) => [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, [`ExtendedScope`](../../types/type-aliases/ExtendedScope.md)\<`S`, `N`, `A`\>, `E2` \| `E1`\>
 
-Defined in: [do.ts:32](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/do.ts#L32)
+Defined in: [do.ts:154](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/do.ts#L154)
+
+Async sibling of [bindR](bindR.md): adds a named field to an async do-chain's
+scope.
 
 ## Type Parameters
 
@@ -65,3 +68,23 @@ Defined in: [do.ts:32](https://github.com/konker/konker.dev/blob/main/packages/n
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R1` & `R2`, [`ExtendedScope`](../../types/type-aliases/ExtendedScope.md)\<`S`, `N`, `A`\>, `E2` \| `E1`\>
+
+## Example
+
+```ts
+import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { bindAsyncR, doAsyncR } from '@konker.dev/neverthrow-r/do';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const program = pipe(
+  doAsyncR(),
+  bindAsyncR('a', () => okAsyncR<number>(2)),
+  bindAsyncR('b', ({ a }) => okAsyncR<number>(a * 10)),
+);
+
+program(undefined); // ResultAsync resolving to Ok({ a: 2, b: 20 })
+```
+
+## See
+
+[bindR](bindR.md)

--- a/packages/neverthrow-r/docs/reference/do/functions/bindR.md
+++ b/packages/neverthrow-r/docs/reference/do/functions/bindR.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [do](../README.md) / bindR
+[@konker.dev/neverthrow-r](../../modules.md) / [do](../README.md) / bindR
 
 # Function: bindR()
 
 > **bindR**\<`N`, `S`, `R2`, `A`, `E2`\>(`name`, `f`): \<`R1`, `E1`\>(`rr`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R1` & `R2`, [`ExtendedScope`](../../types/type-aliases/ExtendedScope.md)\<`S`, `N`, `A`\>, `E2` \| `E1`\>
 
-Defined in: [do.ts:26](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/do.ts#L26)
+Defined in: [do.ts:127](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/do.ts#L127)
+
+Adds a named field to a do-chain's scope.
 
 ## Type Parameters
 
@@ -16,21 +18,31 @@ Defined in: [do.ts:26](https://github.com/konker/konker.dev/blob/main/packages/n
 
 `N` *extends* `string`
 
+The string-literal name of the field being added.
+
 ### S
 
 `S` *extends* `object`
+
+The current scope record.
 
 ### R2
 
 `R2`
 
+The step's requirements.
+
 ### A
 
 `A`
 
+The value being bound.
+
 ### E2
 
 `E2`
+
+The step's error type.
 
 ## Parameters
 
@@ -38,9 +50,13 @@ Defined in: [do.ts:26](https://github.com/konker/konker.dev/blob/main/packages/n
 
 `N`
 
+The field name to bind under.
+
 ### f
 
 (`s`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R2`, `A`, `E2`\>
+
+Function from current scope to the next step's `ResultR`.
 
 ## Returns
 
@@ -65,3 +81,33 @@ Defined in: [do.ts:26](https://github.com/konker/konker.dev/blob/main/packages/n
 ### Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R1` & `R2`, [`ExtendedScope`](../../types/type-aliases/ExtendedScope.md)\<`S`, `N`, `A`\>, `E2` \| `E1`\>
+
+## Remarks
+
+`bindR('name', f)` runs `f(scope)` and, on success, attaches its value at
+key `name` in the scope record. The step's requirements `R2` are
+intersected (`R1 & R2`) and its error type `E2` is unioned (`E1 | E2`).
+
+The callback receives the *current* scope, so later binds can depend on
+earlier ones — a key ergonomic win over a flat sequence of andThen.
+
+## Example
+
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { bindR, doR } from '@konker.dev/neverthrow-r/do';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const program = pipe(
+  doR(),
+  bindR('a', () => okR<number>(2)),
+  bindR('b', ({ a }) => okR<number>(a * 10)),
+);
+
+program(undefined); // Ok({ a: 2, b: 20 })
+```
+
+## See
+
+ - [bindAsyncR](bindAsyncR.md)
+ - [ExtendedScope](../../types/type-aliases/ExtendedScope.md)

--- a/packages/neverthrow-r/docs/reference/do/functions/doAsyncR.md
+++ b/packages/neverthrow-r/docs/reference/do/functions/doAsyncR.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [do](../README.md) / doAsyncR
+[@konker.dev/neverthrow-r](../../modules.md) / [do](../README.md) / doAsyncR
 
 # Function: doAsyncR()
 
 > **doAsyncR**\<`R`\>(): [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `Record`\<`never`, `never`\>, `never`\>
 
-Defined in: [do.ts:21](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/do.ts#L21)
+Defined in: [do.ts:84](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/do.ts#L84)
+
+Async sibling of [doR](doR.md): seeds a do-chain with an empty scope over a
+`ResultAsyncR`.
 
 ## Type Parameters
 
@@ -19,3 +22,16 @@ Defined in: [do.ts:21](https://github.com/konker/konker.dev/blob/main/packages/n
 ## Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `Record`\<`never`, `never`\>, `never`\>
+
+## Example
+
+```ts
+import { doAsyncR } from '@konker.dev/neverthrow-r/do';
+
+const start = doAsyncR();
+start(undefined); // ResultAsync resolving to Ok({})
+```
+
+## See
+
+[doR](doR.md)

--- a/packages/neverthrow-r/docs/reference/do/functions/doR.md
+++ b/packages/neverthrow-r/docs/reference/do/functions/doR.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [do](../README.md) / doR
+[@konker.dev/neverthrow-r](../../modules.md) / [do](../README.md) / doR
 
 # Function: doR()
 
 > **doR**\<`R`\>(): [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `Record`\<`never`, `never`\>, `never`\>
 
-Defined in: [do.ts:16](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/do.ts#L16)
+Defined in: [do.ts:65](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/do.ts#L65)
+
+Seeds a do-chain with an empty scope record `{}` over a `ResultR`.
 
 ## Type Parameters
 
@@ -16,6 +18,28 @@ Defined in: [do.ts:16](https://github.com/konker/konker.dev/blob/main/packages/n
 
 `R` = `unknown`
 
+The chain's requirements (defaults to `unknown`).
+
 ## Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `Record`\<`never`, `never`\>, `never`\>
+
+## Remarks
+
+Pass an explicit type argument when you want to fix the chain's
+requirements up front; otherwise leave it as `unknown` and let downstream
+[bindR](bindR.md) calls accumulate requirements via intersection.
+
+## Example
+
+```ts
+import { doR } from '@konker.dev/neverthrow-r/do';
+
+const start = doR();
+start(undefined); // Ok({})
+```
+
+## See
+
+ - [doAsyncR](doAsyncR.md)
+ - [bindR](bindR.md)

--- a/packages/neverthrow-r/docs/reference/index/README.md
+++ b/packages/neverthrow-r/docs/reference/index/README.md
@@ -2,14 +2,40 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../README.md) / index
+[@konker.dev/neverthrow-r](../modules.md) / index
 
 # index
 
-Public barrel for `@konker.dev/neverthrow-r`: a thin Reader-function layer
-over neverthrow that adds a third "requirements" channel (`R`) to `Result`
-and `ResultAsync`. Re-exports every public type, constructor, operator,
-bridge, do-notation helper, provision function, and `pipe`.
+Public barrel for `@konker.dev/neverthrow-r` — a thin Reader-function layer
+over `neverthrow` that adds a third *requirements* channel `R` alongside
+the usual `T` / `E` of `Result`.
+
+## Remarks
+
+Re-exports every public type, constructor, operator, bridge, do-notation
+helper, provision function, and `pipe`. For a guided tour and "pick your
+module" table, see the package landing page; for the conceptual model of
+the `R` channel, see [types](../types/README.md).
+
+## Example
+
+```ts
+import {
+  andThen,
+  map,
+  okR,
+  pipe,
+  provide,
+} from '@konker.dev/neverthrow-r';
+
+const program = pipe(
+  okR<number>(2),
+  map((n) => n + 1),
+  andThen((n) => okR<string>(`got ${n}`)),
+);
+
+provide(program, undefined); // Ok('got 3')
+```
 
 ## References
 

--- a/packages/neverthrow-r/docs/reference/modules.md
+++ b/packages/neverthrow-r/docs/reference/modules.md
@@ -1,0 +1,17 @@
+[**@konker.dev/neverthrow-r**](README.md)
+
+***
+
+# @konker.dev/neverthrow-r
+
+## Modules
+
+- [async](async/README.md)
+- [bridges](bridges/README.md)
+- [constructors](constructors/README.md)
+- [do](do/README.md)
+- [index](index/README.md)
+- [pipe](pipe/README.md)
+- [provide](provide/README.md)
+- [sync](sync/README.md)
+- [types](types/README.md)

--- a/packages/neverthrow-r/docs/reference/pipe/README.md
+++ b/packages/neverthrow-r/docs/reference/pipe/README.md
@@ -2,15 +2,35 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../README.md) / pipe
+[@konker.dev/neverthrow-r](../modules.md) / pipe
 
 # pipe
 
-Small value-piping `pipe` implementation, applying up to 20 unary
-functions left-to-right with preserved inferred output types. Bundled so
-`neverthrow-r` doesn't drag in a heavier fp library purely for `pipe`;
-operators remain shape-compatible with any external `pipe` consumers
-already use (`effect`, `fp-ts`, `remeda`, …).
+Left-to-right function composition. Bundled so `neverthrow-r` doesn't drag
+in a heavier fp library purely for `pipe`; signature is shape-compatible
+with the `pipe` used by `effect`, `fp-ts`, `remeda`, and similar.
+
+## Remarks
+
+Every combinator in this package is curried so the operand `ResultR`
+arrives last, making `pipe` the natural composition tool: feed the seed
+value first, then list the operators in order.
+
+## Example
+
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { andThen, map } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const program = pipe(
+  okR<number>(2),
+  map((n) => n + 1),
+  andThen((n) => okR<string>(`got ${n}`)),
+);
+
+program(undefined); // Ok('got 3')
+```
 
 ## Functions
 

--- a/packages/neverthrow-r/docs/reference/pipe/functions/pipe.md
+++ b/packages/neverthrow-r/docs/reference/pipe/functions/pipe.md
@@ -2,7 +2,7 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [pipe](../README.md) / pipe
+[@konker.dev/neverthrow-r](../../modules.md) / [pipe](../README.md) / pipe
 
 # Function: pipe()
 
@@ -10,13 +10,19 @@
 
 > **pipe**\<`A`\>(`value`): `A`
 
-Defined in: [pipe.ts:13](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L13)
+Defined in: [pipe.ts:64](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L64)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 ### Parameters
 
@@ -24,21 +30,56 @@ Defined in: [pipe.ts:13](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 ### Returns
 
 `A`
+
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
 
 ## Call Signature
 
 > **pipe**\<`A`, `B`\>(`value`, `ab`): `B`
 
-Defined in: [pipe.ts:14](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L14)
+Defined in: [pipe.ts:65](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L65)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -50,6 +91,8 @@ Defined in: [pipe.ts:14](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -58,17 +101,50 @@ Defined in: [pipe.ts:14](https://github.com/konker/konker.dev/blob/main/packages
 
 `B`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`\>(`value`, `ab`, `bc`): `C`
 
-Defined in: [pipe.ts:15](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L15)
+Defined in: [pipe.ts:66](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L66)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -84,6 +160,8 @@ Defined in: [pipe.ts:15](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -96,17 +174,50 @@ Defined in: [pipe.ts:15](https://github.com/konker/konker.dev/blob/main/packages
 
 `C`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`\>(`value`, `ab`, `bc`, `cd`): `D`
 
-Defined in: [pipe.ts:16](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L16)
+Defined in: [pipe.ts:67](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L67)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -126,6 +237,8 @@ Defined in: [pipe.ts:16](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -142,17 +255,50 @@ Defined in: [pipe.ts:16](https://github.com/konker/konker.dev/blob/main/packages
 
 `D`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`\>(`value`, `ab`, `bc`, `cd`, `de`): `E`
 
-Defined in: [pipe.ts:17](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L17)
+Defined in: [pipe.ts:68](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L68)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -176,6 +322,8 @@ Defined in: [pipe.ts:17](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -196,17 +344,50 @@ Defined in: [pipe.ts:17](https://github.com/konker/konker.dev/blob/main/packages
 
 `E`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`): `F`
 
-Defined in: [pipe.ts:24](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L24)
+Defined in: [pipe.ts:75](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L75)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -234,6 +415,8 @@ Defined in: [pipe.ts:24](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -258,17 +441,50 @@ Defined in: [pipe.ts:24](https://github.com/konker/konker.dev/blob/main/packages
 
 `F`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`): `G`
 
-Defined in: [pipe.ts:32](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L32)
+Defined in: [pipe.ts:83](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L83)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -300,6 +516,8 @@ Defined in: [pipe.ts:32](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -328,17 +546,50 @@ Defined in: [pipe.ts:32](https://github.com/konker/konker.dev/blob/main/packages
 
 `G`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`): `H`
 
-Defined in: [pipe.ts:41](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L41)
+Defined in: [pipe.ts:92](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L92)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -374,6 +625,8 @@ Defined in: [pipe.ts:41](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -406,17 +659,50 @@ Defined in: [pipe.ts:41](https://github.com/konker/konker.dev/blob/main/packages
 
 `H`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`): `I`
 
-Defined in: [pipe.ts:51](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L51)
+Defined in: [pipe.ts:102](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L102)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -456,6 +742,8 @@ Defined in: [pipe.ts:51](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -492,17 +780,50 @@ Defined in: [pipe.ts:51](https://github.com/konker/konker.dev/blob/main/packages
 
 `I`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`): `J`
 
-Defined in: [pipe.ts:62](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L62)
+Defined in: [pipe.ts:113](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L113)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -546,6 +867,8 @@ Defined in: [pipe.ts:62](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -586,17 +909,50 @@ Defined in: [pipe.ts:62](https://github.com/konker/konker.dev/blob/main/packages
 
 `J`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`): `K`
 
-Defined in: [pipe.ts:74](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L74)
+Defined in: [pipe.ts:125](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L125)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -644,6 +1000,8 @@ Defined in: [pipe.ts:74](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -688,17 +1046,50 @@ Defined in: [pipe.ts:74](https://github.com/konker/konker.dev/blob/main/packages
 
 `K`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`, `kl`): `L`
 
-Defined in: [pipe.ts:87](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L87)
+Defined in: [pipe.ts:138](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L138)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -750,6 +1141,8 @@ Defined in: [pipe.ts:87](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -798,17 +1191,50 @@ Defined in: [pipe.ts:87](https://github.com/konker/konker.dev/blob/main/packages
 
 `L`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`, `kl`, `lm`): `M`
 
-Defined in: [pipe.ts:101](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L101)
+Defined in: [pipe.ts:152](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L152)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -864,6 +1290,8 @@ Defined in: [pipe.ts:101](https://github.com/konker/konker.dev/blob/main/package
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -916,17 +1344,50 @@ Defined in: [pipe.ts:101](https://github.com/konker/konker.dev/blob/main/package
 
 `M`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`, `N`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`, `kl`, `lm`, `mn`): `N`
 
-Defined in: [pipe.ts:116](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L116)
+Defined in: [pipe.ts:167](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L167)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -986,6 +1447,8 @@ Defined in: [pipe.ts:116](https://github.com/konker/konker.dev/blob/main/package
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -1042,17 +1505,50 @@ Defined in: [pipe.ts:116](https://github.com/konker/konker.dev/blob/main/package
 
 `N`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`, `N`, `O`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`, `kl`, `lm`, `mn`, `no`): `O`
 
-Defined in: [pipe.ts:132](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L132)
+Defined in: [pipe.ts:183](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L183)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -1116,6 +1612,8 @@ Defined in: [pipe.ts:132](https://github.com/konker/konker.dev/blob/main/package
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -1176,17 +1674,50 @@ Defined in: [pipe.ts:132](https://github.com/konker/konker.dev/blob/main/package
 
 `O`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`, `N`, `O`, `P`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`, `kl`, `lm`, `mn`, `no`, `op`): `P`
 
-Defined in: [pipe.ts:149](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L149)
+Defined in: [pipe.ts:200](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L200)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -1254,6 +1785,8 @@ Defined in: [pipe.ts:149](https://github.com/konker/konker.dev/blob/main/package
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -1318,17 +1851,50 @@ Defined in: [pipe.ts:149](https://github.com/konker/konker.dev/blob/main/package
 
 `P`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`, `N`, `O`, `P`, `Q`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`, `kl`, `lm`, `mn`, `no`, `op`, `pq`): `Q`
 
-Defined in: [pipe.ts:167](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L167)
+Defined in: [pipe.ts:218](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L218)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -1400,6 +1966,8 @@ Defined in: [pipe.ts:167](https://github.com/konker/konker.dev/blob/main/package
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -1468,17 +2036,50 @@ Defined in: [pipe.ts:167](https://github.com/konker/konker.dev/blob/main/package
 
 `Q`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`, `N`, `O`, `P`, `Q`, `R`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`, `kl`, `lm`, `mn`, `no`, `op`, `pq`, `qr`): `R`
 
-Defined in: [pipe.ts:186](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L186)
+Defined in: [pipe.ts:237](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L237)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -1554,6 +2155,8 @@ Defined in: [pipe.ts:186](https://github.com/konker/konker.dev/blob/main/package
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -1626,17 +2229,50 @@ Defined in: [pipe.ts:186](https://github.com/konker/konker.dev/blob/main/package
 
 `R`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`, `N`, `O`, `P`, `Q`, `R`, `S`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`, `kl`, `lm`, `mn`, `no`, `op`, `pq`, `qr`, `rs`): `S`
 
-Defined in: [pipe.ts:206](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L206)
+Defined in: [pipe.ts:257](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L257)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -1716,6 +2352,8 @@ Defined in: [pipe.ts:206](https://github.com/konker/konker.dev/blob/main/package
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -1792,17 +2430,50 @@ Defined in: [pipe.ts:206](https://github.com/konker/konker.dev/blob/main/package
 
 `S`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`, `N`, `O`, `P`, `Q`, `R`, `S`, `T`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`, `kl`, `lm`, `mn`, `no`, `op`, `pq`, `qr`, `rs`, `st`): `T`
 
-Defined in: [pipe.ts:227](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L227)
+Defined in: [pipe.ts:278](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L278)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -1886,6 +2557,8 @@ Defined in: [pipe.ts:227](https://github.com/konker/konker.dev/blob/main/package
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -1966,17 +2639,50 @@ Defined in: [pipe.ts:227](https://github.com/konker/konker.dev/blob/main/package
 
 `T`
 
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```
+
 ## Call Signature
 
 > **pipe**\<`A`, `B`, `C`, `D`, `E`, `F`, `G`, `H`, `I`, `J`, `K`, `L`, `M`, `N`, `O`, `P`, `Q`, `R`, `S`, `T`, `U`\>(`value`, `ab`, `bc`, `cd`, `de`, `ef`, `fg`, `gh`, `hi`, `ij`, `jk`, `kl`, `lm`, `mn`, `no`, `op`, `pq`, `qr`, `rs`, `st`, `tu`): `U`
 
-Defined in: [pipe.ts:249](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L249)
+Defined in: [pipe.ts:300](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/pipe.ts#L300)
+
+Applies a chain of unary functions left-to-right to an initial value, with
+each function's output type inferred and propagated to the next.
 
 ### Type Parameters
 
 #### A
 
 `A`
+
+The initial value's type. Subsequent overloads add type
+  parameters for each intermediate output.
 
 #### B
 
@@ -2064,6 +2770,8 @@ Defined in: [pipe.ts:249](https://github.com/konker/konker.dev/blob/main/package
 
 `A`
 
+The initial value.
+
 #### ab
 
 `UnaryFn`\<`A`, `B`\>
@@ -2147,3 +2855,30 @@ Defined in: [pipe.ts:249](https://github.com/konker/konker.dev/blob/main/package
 ### Returns
 
 `U`
+
+The final value after all functions have been applied. With no
+  functions, the input is returned unchanged.
+
+### Remarks
+
+Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+group functions with an intermediate `pipe(...)` call or extract a
+sub-chain into a named function.
+
+Every [sync](../../sync/README.md), [async](../../async/README.md), [bridges](../../bridges/README.md), and [do](../../do/README.md)
+combinator returns a unary function shaped for `pipe`, so the typical
+pattern is `pipe(seed, op1, op2, …)`.
+
+### Example
+
+```ts
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const result = pipe(
+  2,
+  (n) => n + 1,
+  (n) => n * 10,
+  (n) => `value: ${n}`,
+);
+// result is 'value: 30'
+```

--- a/packages/neverthrow-r/docs/reference/provide/README.md
+++ b/packages/neverthrow-r/docs/reference/provide/README.md
@@ -2,15 +2,36 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../README.md) / provide
+[@konker.dev/neverthrow-r](../modules.md) / provide
 
 # provide
 
-Provision: supply the environment to a `ResultR` / `ResultAsyncR` and
-obtain the underlying neverthrow value. `provide(rr, deps)` is the named
-alias for `rr(deps)` with explicit type narrowing. `provideSome(rr, p)`
-whole-replaces a subset of requirement keys and returns a `ResultR` over
-the remaining ones (no deep merge).
+Provision: supply the accumulated requirements `R` to a `ResultR` /
+`ResultAsyncR` and exit back into a plain `neverthrow` `Result` /
+`ResultAsync`.
+
+## Remarks
+
+The rest of the package builds up an `R` channel through intersection;
+this module is where you discharge it. Two flavours:
+
+- [provide](functions/provide.md) — supply the full environment in one call. Returns the
+  underlying `Result` (or `ResultAsync`).
+- [provideSome](functions/provideSome.md) — supply a *subset* of the requirements. Returns a
+  new `ResultR` over the keys that remain unsatisfied.
+
+## Example
+
+```ts
+import { asks } from '@konker.dev/neverthrow-r/constructors';
+import { provide } from '@konker.dev/neverthrow-r/provide';
+
+type Deps = { factor: number };
+
+const program = asks((r: Deps) => r.factor * 2);
+
+provide(program, { factor: 10 }); // Ok(20)
+```
 
 ## Functions
 

--- a/packages/neverthrow-r/docs/reference/provide/functions/provide.md
+++ b/packages/neverthrow-r/docs/reference/provide/functions/provide.md
@@ -2,7 +2,7 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [provide](../README.md) / provide
+[@konker.dev/neverthrow-r](../../modules.md) / [provide](../README.md) / provide
 
 # Function: provide()
 
@@ -10,7 +10,10 @@
 
 > **provide**\<`R`, `T`, `E`\>(`rr`, `deps`): `Result`\<`T`, `E`\>
 
-Defined in: [provide.ts:15](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/provide.ts#L15)
+Defined in: [provide.ts:72](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/provide.ts#L72)
+
+Supplies the environment to a `ResultR` (or `ResultAsyncR`) and returns
+the underlying neverthrow value.
 
 ### Type Parameters
 
@@ -18,13 +21,19 @@ Defined in: [provide.ts:15](https://github.com/konker/konker.dev/blob/main/packa
 
 `R`
 
+The requirements being supplied.
+
 #### T
 
 `T`
 
+The success type.
+
 #### E
 
 `E`
+
+The error type.
 
 ### Parameters
 
@@ -32,19 +41,56 @@ Defined in: [provide.ts:15](https://github.com/konker/konker.dev/blob/main/packa
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `T`, `E`\>
 
+The `ResultR` or `ResultAsyncR` to provide for.
+
 #### deps
 
 `R`
+
+The environment.
 
 ### Returns
 
 `Result`\<`T`, `E`\>
 
+### Remarks
+
+Equivalent to calling `rr(deps)` directly, but named for intent and
+overloaded so the return type tracks whether the input is sync or async.
+
+Typically the final call in a pipeline: composition builds a `ResultR<R, T,
+E>`; `provide` discharges `R`.
+
+### Examples
+
+Sync:
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { provide } from '@konker.dev/neverthrow-r/provide';
+
+provide(okR<number>(2), undefined); // Ok(2)
+```
+
+Async:
+```ts
+import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { provide } from '@konker.dev/neverthrow-r/provide';
+
+provide(okAsyncR<number>(2), undefined); // ResultAsync resolving to Ok(2)
+```
+
+### See
+
+[provideSome](provideSome.md)
+
 ## Call Signature
 
 > **provide**\<`R`, `T`, `E`\>(`rr`, `deps`): `ResultAsync`\<`T`, `E`\>
 
-Defined in: [provide.ts:16](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/provide.ts#L16)
+Defined in: [provide.ts:73](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/provide.ts#L73)
+
+Supplies the environment to a `ResultR` (or `ResultAsyncR`) and returns
+the underlying neverthrow value.
 
 ### Type Parameters
 
@@ -52,13 +98,19 @@ Defined in: [provide.ts:16](https://github.com/konker/konker.dev/blob/main/packa
 
 `R`
 
+The requirements being supplied.
+
 #### T
 
 `T`
 
+The success type.
+
 #### E
 
 `E`
+
+The error type.
 
 ### Parameters
 
@@ -66,10 +118,44 @@ Defined in: [provide.ts:16](https://github.com/konker/konker.dev/blob/main/packa
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `T`, `E`\>
 
+The `ResultR` or `ResultAsyncR` to provide for.
+
 #### deps
 
 `R`
 
+The environment.
+
 ### Returns
 
 `ResultAsync`\<`T`, `E`\>
+
+### Remarks
+
+Equivalent to calling `rr(deps)` directly, but named for intent and
+overloaded so the return type tracks whether the input is sync or async.
+
+Typically the final call in a pipeline: composition builds a `ResultR<R, T,
+E>`; `provide` discharges `R`.
+
+### Examples
+
+Sync:
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { provide } from '@konker.dev/neverthrow-r/provide';
+
+provide(okR<number>(2), undefined); // Ok(2)
+```
+
+Async:
+```ts
+import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+import { provide } from '@konker.dev/neverthrow-r/provide';
+
+provide(okAsyncR<number>(2), undefined); // ResultAsync resolving to Ok(2)
+```
+
+### See
+
+[provideSome](provideSome.md)

--- a/packages/neverthrow-r/docs/reference/provide/functions/provideSome.md
+++ b/packages/neverthrow-r/docs/reference/provide/functions/provideSome.md
@@ -2,7 +2,7 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [provide](../README.md) / provideSome
+[@konker.dev/neverthrow-r](../../modules.md) / [provide](../README.md) / provideSome
 
 # Function: provideSome()
 
@@ -10,7 +10,10 @@
 
 > **provideSome**\<`R`, `T`, `E`, `P`\>(`rr`, `partial`): [`ResultR`](../../types/type-aliases/ResultR.md)\<\{ \[K in string \| number \| symbol\]: Omit\<R, keyof P\>\[K\] \}, `T`, `E`\>
 
-Defined in: [provide.ts:24](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/provide.ts#L24)
+Defined in: [provide.ts:123](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/provide.ts#L123)
+
+Supplies a *subset* of the requirements, returning a new `ResultR` whose
+`R` is narrowed to the remaining keys.
 
 ### Type Parameters
 
@@ -18,17 +21,25 @@ Defined in: [provide.ts:24](https://github.com/konker/konker.dev/blob/main/packa
 
 `R`
 
+The full requirements of `rr`.
+
 #### T
 
 `T`
+
+The success type.
 
 #### E
 
 `E`
 
+The error type.
+
 #### P
 
 `P` *extends* `Partial`\<`R`\>
+
+The subset of `R` being supplied.
 
 ### Parameters
 
@@ -36,19 +47,60 @@ Defined in: [provide.ts:24](https://github.com/konker/konker.dev/blob/main/packa
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `T`, `E`\>
 
+The `ResultR` or `ResultAsyncR` to partially provide for.
+
 #### partial
 
 `P`
+
+The subset of requirements to inject now.
 
 ### Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<\{ \[K in string \| number \| symbol\]: Omit\<R, keyof P\>\[K\] \}, `T`, `E`\>
 
+### Remarks
+
+Useful for satisfying part of an environment at one level of an
+application (e.g. injecting a config singleton in `main`) while leaving the
+rest to be supplied later (e.g. a per-request handle).
+
+The merge is shallow: `partial` and the runtime `rest` are spread into a
+single object, with `partial` taking precedence on conflicting keys. There
+is no deep merge — if a requirement value is a nested object, supply the
+whole nested object in one call, not in pieces across two `provideSome`s.
+
+The return type uses [Simplify](../../types/type-aliases/Simplify.md) to flatten `Omit<R, keyof P>` for a
+clean inferred display.
+
+### Example
+
+```ts
+import { asks } from '@konker.dev/neverthrow-r/constructors';
+import { provide, provideSome } from '@konker.dev/neverthrow-r/provide';
+
+type Deps = { config: { name: string }; handle: number };
+
+const program = asks((r: Deps) => `${r.config.name}#${r.handle}`);
+
+// Pre-inject config; defer handle to later.
+const withConfig = provideSome(program, { config: { name: 'svc' } });
+
+provide(withConfig, { handle: 42 }); // Ok('svc#42')
+```
+
+### See
+
+[provide](provide.md)
+
 ## Call Signature
 
 > **provideSome**\<`R`, `T`, `E`, `P`\>(`rr`, `partial`): [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<\{ \[K in string \| number \| symbol\]: Omit\<R, keyof P\>\[K\] \}, `T`, `E`\>
 
-Defined in: [provide.ts:28](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/provide.ts#L28)
+Defined in: [provide.ts:127](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/provide.ts#L127)
+
+Supplies a *subset* of the requirements, returning a new `ResultR` whose
+`R` is narrowed to the remaining keys.
 
 ### Type Parameters
 
@@ -56,17 +108,25 @@ Defined in: [provide.ts:28](https://github.com/konker/konker.dev/blob/main/packa
 
 `R`
 
+The full requirements of `rr`.
+
 #### T
 
 `T`
+
+The success type.
 
 #### E
 
 `E`
 
+The error type.
+
 #### P
 
 `P` *extends* `Partial`\<`R`\>
+
+The subset of `R` being supplied.
 
 ### Parameters
 
@@ -74,10 +134,48 @@ Defined in: [provide.ts:28](https://github.com/konker/konker.dev/blob/main/packa
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<`R`, `T`, `E`\>
 
+The `ResultR` or `ResultAsyncR` to partially provide for.
+
 #### partial
 
 `P`
 
+The subset of requirements to inject now.
+
 ### Returns
 
 [`ResultAsyncR`](../../types/type-aliases/ResultAsyncR.md)\<\{ \[K in string \| number \| symbol\]: Omit\<R, keyof P\>\[K\] \}, `T`, `E`\>
+
+### Remarks
+
+Useful for satisfying part of an environment at one level of an
+application (e.g. injecting a config singleton in `main`) while leaving the
+rest to be supplied later (e.g. a per-request handle).
+
+The merge is shallow: `partial` and the runtime `rest` are spread into a
+single object, with `partial` taking precedence on conflicting keys. There
+is no deep merge — if a requirement value is a nested object, supply the
+whole nested object in one call, not in pieces across two `provideSome`s.
+
+The return type uses [Simplify](../../types/type-aliases/Simplify.md) to flatten `Omit<R, keyof P>` for a
+clean inferred display.
+
+### Example
+
+```ts
+import { asks } from '@konker.dev/neverthrow-r/constructors';
+import { provide, provideSome } from '@konker.dev/neverthrow-r/provide';
+
+type Deps = { config: { name: string }; handle: number };
+
+const program = asks((r: Deps) => `${r.config.name}#${r.handle}`);
+
+// Pre-inject config; defer handle to later.
+const withConfig = provideSome(program, { config: { name: 'svc' } });
+
+provide(withConfig, { handle: 42 }); // Ok('svc#42')
+```
+
+### See
+
+[provide](provide.md)

--- a/packages/neverthrow-r/docs/reference/sync/README.md
+++ b/packages/neverthrow-r/docs/reference/sync/README.md
@@ -2,14 +2,41 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../README.md) / sync
+[@konker.dev/neverthrow-r](../modules.md) / sync
 
 # sync
 
-Sync operators over `ResultR`: `map`, `mapErr`, `andThen`, `orElse`,
-`match`, `andTee`, `orTee`, `andThrough`. Each is a one-line delegation to
-the underlying neverthrow `Result` method, threading the environment `r`
-and intersecting requirement types (`R1 & R2`) across composed steps.
+Sync combinators over `ResultR`. This is the canonical surface — the async
+module (mapAsync, andThenAsync, …) mirrors it 1:1 over
+`ResultAsyncR`.
+
+## Remarks
+
+Every combinator is curried so it composes cleanly under [pipe](../pipe/README.md): the
+transforming function comes first, then the operand `ResultR`. Each one
+delegates to the corresponding neverthrow `Result` method, threading the
+environment `r` through and **intersecting** requirements across composed
+steps (`R1 & R2`).
+
+Reach for this module when the whole chain is synchronous. The moment a
+step needs to await, switch into [bridges](../bridges/README.md) (sync→async one-shot) or
+the [async](../async/README.md) module (already-async chain).
+
+## Example
+
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { andThen, map } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const program = pipe(
+  okR<number>(2),
+  map((n) => n + 1),
+  andThen((n) => okR<string>(`got ${n}`)),
+);
+
+program(undefined); // Ok('got 3')
+```
 
 ## Functions
 

--- a/packages/neverthrow-r/docs/reference/sync/functions/andTee.md
+++ b/packages/neverthrow-r/docs/reference/sync/functions/andTee.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [sync](../README.md) / andTee
+[@konker.dev/neverthrow-r](../../modules.md) / [sync](../README.md) / andTee
 
 # Function: andTee()
 
 > **andTee**\<`T`\>(`f`): \<`R`, `E`\>(`rr`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `T`, `E`\>
 
-Defined in: [sync.ts:43](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L43)
+Defined in: [sync.ts:277](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L277)
+
+Runs a side effect with the success value, propagating the value unchanged.
 
 ## Type Parameters
 
@@ -16,11 +18,15 @@ Defined in: [sync.ts:43](https://github.com/konker/konker.dev/blob/main/packages
 
 `T`
 
+The success type (preserved through the step).
+
 ## Parameters
 
 ### f
 
 (`t`) => `unknown`
+
+Side-effecting callback receiving the success value.
 
 ## Returns
 
@@ -45,3 +51,30 @@ Defined in: [sync.ts:43](https://github.com/konker/konker.dev/blob/main/packages
 ### Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `T`, `E`\>
+
+## Remarks
+
+Pass-through combinator for logging, telemetry, or any other observe-only
+step. The callback's return value is discarded; the chain continues with
+the original `T`. The callback is not invoked when the chain is in `Err`.
+
+## Example
+
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { andTee } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const traced = pipe(
+  okR<number>(2),
+  andTee((n) => console.log('saw', n)),
+);
+
+traced(undefined); // logs 'saw 2', returns Ok(2)
+```
+
+## See
+
+ - [orTee](orTee.md)
+ - [andThrough](andThrough.md) for a tee that can itself fail.
+ - andTeeAsync

--- a/packages/neverthrow-r/docs/reference/sync/functions/andThen.md
+++ b/packages/neverthrow-r/docs/reference/sync/functions/andThen.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [sync](../README.md) / andThen
+[@konker.dev/neverthrow-r](../../modules.md) / [sync](../README.md) / andThen
 
 # Function: andThen()
 
 > **andThen**\<`A`, `R2`, `B`, `E2`\>(`f`): \<`R1`, `E1`\>(`rr`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R1` & `R2`, `B`, `E2` \| `E1`\>
 
-Defined in: [sync.ts:25](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L25)
+Defined in: [sync.ts:158](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L158)
+
+Chains another `ResultR`-returning step onto a successful result.
 
 ## Type Parameters
 
@@ -16,17 +18,25 @@ Defined in: [sync.ts:25](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The previous step's success type.
+
 ### R2
 
 `R2`
+
+The continuation's requirements.
 
 ### B
 
 `B`
 
+The continuation's success type.
+
 ### E2
 
 `E2`
+
+The continuation's error type.
 
 ## Parameters
 
@@ -34,7 +44,12 @@ Defined in: [sync.ts:25](https://github.com/konker/konker.dev/blob/main/packages
 
 (`a`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R2`, `B`, `E2`\>
 
+Function from the previous success value to a `ResultR`.
+
 ## Returns
+
+A function taking a `ResultR<R1, A, E1>` and returning a
+  `ResultR<R1 & R2, B, E1 | E2>`.
 
 > \<`R1`, `E1`\>(`rr`): [`ResultR`](../../types/type-aliases/ResultR.md)\<`R1` & `R2`, `B`, `E2` \| `E1`\>
 
@@ -57,3 +72,41 @@ Defined in: [sync.ts:25](https://github.com/konker/konker.dev/blob/main/packages
 ### Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R1` & `R2`, `B`, `E2` \| `E1`\>
+
+## Remarks
+
+This is the workhorse for sequencing computations that each may fail. The
+continuation `f` receives the previous step's success value and returns a
+new `ResultR` whose requirements `R2` are **intersected** into the chain
+(`R1 & R2`) and whose error type `E2` is **unioned** with the chain's
+(`E1 | E2`).
+
+If the previous step is an `Err`, `f` is not called and the error
+propagates.
+
+For multi-step chains that accumulate intermediate values into a named
+scope, prefer the do-notation helpers in [do](../../do/README.md).
+
+## Example
+
+```ts
+import { asks, okR } from '@konker.dev/neverthrow-r/constructors';
+import { andThen } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+type Config = { factor: number };
+
+const program = pipe(
+  okR<number>(2),
+  andThen((n) => asks((r: Config) => n * r.factor)),
+);
+
+program({ factor: 10 }); // Ok(20)
+```
+
+## See
+
+ - [orElse](orElse.md) for the error-channel mirror.
+ - [andThrough](andThrough.md) for a chain that returns the previous value.
+ - andThenAsync
+ - bindR

--- a/packages/neverthrow-r/docs/reference/sync/functions/andThrough.md
+++ b/packages/neverthrow-r/docs/reference/sync/functions/andThrough.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [sync](../README.md) / andThrough
+[@konker.dev/neverthrow-r](../../modules.md) / [sync](../README.md) / andThrough
 
 # Function: andThrough()
 
 > **andThrough**\<`T`, `R2`, `F`\>(`f`): \<`R1`, `E`\>(`rr`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R1` & `R2`, `T`, `F` \| `E`\>
 
-Defined in: [sync.ts:55](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L55)
+Defined in: [sync.ts:354](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L354)
+
+Runs a fallible step for its side effect, then propagates the original
+success value if the step succeeds.
 
 ## Type Parameters
 
@@ -16,19 +19,28 @@ Defined in: [sync.ts:55](https://github.com/konker/konker.dev/blob/main/packages
 
 `T`
 
+The success type (preserved through the step on success).
+
 ### R2
 
 `R2`
 
+The tee's requirements (intersected into the chain).
+
 ### F
 
 `F`
+
+The tee's error type (unioned with the chain's).
 
 ## Parameters
 
 ### f
 
 (`t`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R2`, `unknown`, `F`\>
+
+Function from the success value to a `ResultR` whose value is
+  ignored on success.
 
 ## Returns
 
@@ -53,3 +65,33 @@ Defined in: [sync.ts:55](https://github.com/konker/konker.dev/blob/main/packages
 ### Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R1` & `R2`, `T`, `F` \| `E`\>
+
+## Remarks
+
+Like [andTee](andTee.md), but the tee step is itself a `ResultR` that can fail.
+If the tee step returns `Err`, that error replaces the chain's value; if it
+returns `Ok`, the chain continues with the *original* success value (the
+tee's success value is discarded).
+
+Common shape: validate a value via a fallible check without losing the
+value itself.
+
+## Example
+
+```ts
+import { errR, okR } from '@konker.dev/neverthrow-r/constructors';
+import { andThrough } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const validated = pipe(
+  okR<number>(2),
+  andThrough((n) => (n > 0 ? okR<unknown>(undefined) : errR<string>('non-positive'))),
+);
+
+validated(undefined); // Ok(2)
+```
+
+## See
+
+ - [andTee](andTee.md) for the infallible version.
+ - andThroughAsync

--- a/packages/neverthrow-r/docs/reference/sync/functions/map.md
+++ b/packages/neverthrow-r/docs/reference/sync/functions/map.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [sync](../README.md) / map
+[@konker.dev/neverthrow-r](../../modules.md) / [sync](../README.md) / map
 
 # Function: map()
 
 > **map**\<`A`, `B`\>(`f`): \<`R`, `E`\>(`rr`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `B`, `E`\>
 
-Defined in: [sync.ts:13](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L13)
+Defined in: [sync.ts:70](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L70)
+
+Transforms the success value of a `ResultR` with a pure function.
 
 ## Type Parameters
 
@@ -16,9 +18,13 @@ Defined in: [sync.ts:13](https://github.com/konker/konker.dev/blob/main/packages
 
 `A`
 
+The input success type.
+
 ### B
 
 `B`
+
+The output success type.
 
 ## Parameters
 
@@ -26,7 +32,12 @@ Defined in: [sync.ts:13](https://github.com/konker/konker.dev/blob/main/packages
 
 (`a`) => `B`
 
+Pure transformation from `A` to `B`.
+
 ## Returns
+
+A function taking a `ResultR<R, A, E>` and returning a
+  `ResultR<R, B, E>`.
 
 > \<`R`, `E`\>(`rr`): [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `B`, `E`\>
 
@@ -49,3 +60,29 @@ Defined in: [sync.ts:13](https://github.com/konker/konker.dev/blob/main/packages
 ### Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `B`, `E`\>
+
+## Remarks
+
+Threads `R` and `E` through unchanged; only `T` changes. The wrapped
+function `f` is not called when the underlying `Result` is an `Err`.
+
+To transform the error channel instead, see [mapErr](mapErr.md). To compose
+with another `ResultR`-returning step, use [andThen](andThen.md). For side
+effects on the success value without changing it, use [andTee](andTee.md).
+
+## Example
+
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { map } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const doubled = pipe(okR<number>(2), map((n) => n * 2));
+doubled(undefined); // Ok(4)
+```
+
+## See
+
+ - [mapErr](mapErr.md)
+ - [andThen](andThen.md)
+ - mapAsync

--- a/packages/neverthrow-r/docs/reference/sync/functions/mapErr.md
+++ b/packages/neverthrow-r/docs/reference/sync/functions/mapErr.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [sync](../README.md) / mapErr
+[@konker.dev/neverthrow-r](../../modules.md) / [sync](../README.md) / mapErr
 
 # Function: mapErr()
 
 > **mapErr**\<`E`, `F`\>(`f`): \<`R`, `T`\>(`rr`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `T`, `F`\>
 
-Defined in: [sync.ts:19](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L19)
+Defined in: [sync.ts:106](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L106)
+
+Transforms the error value of a `ResultR` with a pure function.
 
 ## Type Parameters
 
@@ -16,15 +18,21 @@ Defined in: [sync.ts:19](https://github.com/konker/konker.dev/blob/main/packages
 
 `E`
 
+The input error type.
+
 ### F
 
 `F`
+
+The output error type.
 
 ## Parameters
 
 ### f
 
 (`e`) => `F`
+
+Pure transformation from `E` to `F`.
 
 ## Returns
 
@@ -49,3 +57,29 @@ Defined in: [sync.ts:19](https://github.com/konker/konker.dev/blob/main/packages
 ### Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `T`, `F`\>
+
+## Remarks
+
+Symmetric to [map](map.md), but operates on the `E` channel. `T` and `R` pass
+through unchanged. Useful for narrowing a wide error type to a domain-
+specific one, or for annotating where in a pipeline an error occurred.
+
+## Example
+
+```ts
+import { errR } from '@konker.dev/neverthrow-r/constructors';
+import { mapErr } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const annotated = pipe(
+  errR<string>('not found'),
+  mapErr((msg) => ({ tag: 'lookup', message: msg })),
+);
+
+annotated(undefined); // Err({ tag: 'lookup', message: 'not found' })
+```
+
+## See
+
+ - [map](map.md)
+ - mapErrAsync

--- a/packages/neverthrow-r/docs/reference/sync/functions/match.md
+++ b/packages/neverthrow-r/docs/reference/sync/functions/match.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [sync](../README.md) / match
+[@konker.dev/neverthrow-r](../../modules.md) / [sync](../README.md) / match
 
 # Function: match()
 
 > **match**\<`T`, `E`, `A`, `B`\>(`okFn`, `errFn`): \<`R`\>(`rr`) => (`r`) => `A` \| `B`
 
-Defined in: [sync.ts:37](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L37)
+Defined in: [sync.ts:241](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L241)
+
+Eliminates a `ResultR` into a single value by handling both branches.
 
 ## Type Parameters
 
@@ -16,17 +18,25 @@ Defined in: [sync.ts:37](https://github.com/konker/konker.dev/blob/main/packages
 
 `T`
 
+The success type.
+
 ### E
 
 `E`
+
+The error type.
 
 ### A
 
 `A`
 
+The result type of the `Ok` branch.
+
 ### B
 
 `B` = `A`
+
+The result type of the `Err` branch (defaults to `A`).
 
 ## Parameters
 
@@ -34,9 +44,13 @@ Defined in: [sync.ts:37](https://github.com/konker/konker.dev/blob/main/packages
 
 (`t`) => `A`
 
+Handler for the success branch.
+
 ### errFn
 
 (`e`) => `B`
+
+Handler for the error branch.
 
 ## Returns
 
@@ -67,3 +81,34 @@ Defined in: [sync.ts:37](https://github.com/konker/konker.dev/blob/main/packages
 #### Returns
 
 `A` \| `B`
+
+## Remarks
+
+Unlike the other combinators, `match` does not return a `ResultR` — it
+collapses the chain into a plain value. Both branch functions can return
+the same type, or different types that get unioned.
+
+The result is still a function of the environment `R`, so calling it
+requires providing `R` directly (or pulling it via [provide](../../provide/README.md)).
+
+## Example
+
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { match } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const rendered = pipe(
+  okR<number>(42),
+  match(
+    (n) => `got ${n}`,
+    (e: never) => `error: ${String(e)}`,
+  ),
+);
+
+rendered(undefined); // 'got 42'
+```
+
+## See
+
+matchAsync

--- a/packages/neverthrow-r/docs/reference/sync/functions/orElse.md
+++ b/packages/neverthrow-r/docs/reference/sync/functions/orElse.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [sync](../README.md) / orElse
+[@konker.dev/neverthrow-r](../../modules.md) / [sync](../README.md) / orElse
 
 # Function: orElse()
 
 > **orElse**\<`E`, `R2`, `U`, `F`\>(`f`): \<`R1`, `T`\>(`rr`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R1` & `R2`, `U` \| `T`, `F`\>
 
-Defined in: [sync.ts:31](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L31)
+Defined in: [sync.ts:197](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L197)
+
+Recovers from an `Err` by running another `ResultR`-returning step.
 
 ## Type Parameters
 
@@ -16,23 +18,33 @@ Defined in: [sync.ts:31](https://github.com/konker/konker.dev/blob/main/packages
 
 `E`
 
+The previous step's error type.
+
 ### R2
 
 `R2`
+
+The recovery's requirements.
 
 ### U
 
 `U`
 
+The recovery's success type.
+
 ### F
 
 `F`
+
+The recovery's error type.
 
 ## Parameters
 
 ### f
 
 (`e`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R2`, `U`, `F`\>
+
+Function from the previous error to a recovery `ResultR`.
 
 ## Returns
 
@@ -57,3 +69,30 @@ Defined in: [sync.ts:31](https://github.com/konker/konker.dev/blob/main/packages
 ### Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R1` & `R2`, `U` \| `T`, `F`\>
+
+## Remarks
+
+The error-channel mirror of [andThen](andThen.md): `f` is called only when the
+previous step is an `Err`. The recovery's requirements `R2` are intersected
+(`R1 & R2`) and its success type `U` is unioned with the original `T`
+(`T | U`). The recovery itself can still fail, with its own error type `F`.
+
+## Example
+
+```ts
+import { errR, okR } from '@konker.dev/neverthrow-r/constructors';
+import { orElse } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const withFallback = pipe(
+  errR<string, number>('boom'),
+  orElse(() => okR<number>(0)),
+);
+
+withFallback(undefined); // Ok(0)
+```
+
+## See
+
+ - [andThen](andThen.md)
+ - orElseAsync

--- a/packages/neverthrow-r/docs/reference/sync/functions/orTee.md
+++ b/packages/neverthrow-r/docs/reference/sync/functions/orTee.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [sync](../README.md) / orTee
+[@konker.dev/neverthrow-r](../../modules.md) / [sync](../README.md) / orTee
 
 # Function: orTee()
 
 > **orTee**\<`E`\>(`f`): \<`R`, `T`\>(`rr`) => [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `T`, `E`\>
 
-Defined in: [sync.ts:49](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L49)
+Defined in: [sync.ts:311](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/sync.ts#L311)
+
+Runs a side effect with the error value, propagating the error unchanged.
 
 ## Type Parameters
 
@@ -16,11 +18,15 @@ Defined in: [sync.ts:49](https://github.com/konker/konker.dev/blob/main/packages
 
 `E`
 
+The error type (preserved through the step).
+
 ## Parameters
 
 ### f
 
 (`e`) => `unknown`
+
+Side-effecting callback receiving the error value.
 
 ## Returns
 
@@ -45,3 +51,28 @@ Defined in: [sync.ts:49](https://github.com/konker/konker.dev/blob/main/packages
 ### Returns
 
 [`ResultR`](../../types/type-aliases/ResultR.md)\<`R`, `T`, `E`\>
+
+## Remarks
+
+Error-channel mirror of [andTee](andTee.md). Useful for logging failures without
+altering the error type or recovering from it.
+
+## Example
+
+```ts
+import { errR } from '@konker.dev/neverthrow-r/constructors';
+import { orTee } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+
+const logged = pipe(
+  errR<string>('boom'),
+  orTee((e) => console.error('failed:', e)),
+);
+
+logged(undefined); // logs 'failed: boom', returns Err('boom')
+```
+
+## See
+
+ - [andTee](andTee.md)
+ - orTeeAsync

--- a/packages/neverthrow-r/docs/reference/types/README.md
+++ b/packages/neverthrow-r/docs/reference/types/README.md
@@ -2,15 +2,50 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../README.md) / types
+[@konker.dev/neverthrow-r](../modules.md) / types
 
 # types
 
-Core type aliases for the Reader-function layer: `ResultR<R, T, E>` is
-`(r: R) => Result<T, E>` and `ResultAsyncR<R, T, E>` is its async sibling.
-`R` defaults to `unknown` (no specific requirements). Also exposes the
-`Scope` / `ExtendedScope` helpers used by do-notation and the `Simplify`
-intersection-flattener.
+Type-level vocabulary for the package: the `ResultR` / `ResultAsyncR` shapes
+that add a *requirements* channel on top of `neverthrow`'s `Result` /
+`ResultAsync`, plus the helper types (`Scope`, `ExtendedScope`, `Simplify`)
+used by do-notation and intersection flattening.
+
+## Remarks
+
+Most users only need [ResultR](type-aliases/ResultR.md) and [ResultAsyncR](type-aliases/ResultAsyncR.md). The remaining
+exports are surfaced because the do-notation helpers (`bindR`, `bindAsyncR`)
+expose them in their return types, so consumers may encounter them in
+inferred types.
+
+Every operator across the package — sync, async, bridges, do — preserves the
+R/T/E shape and **intersects** the `R` channel across composed steps
+(`R1 & R2`), so requirements accumulate as a chain is built.
+
+## Example
+
+Lift a value, transform it, accumulate requirements, then provide them:
+
+```ts
+import { okR } from '@konker.dev/neverthrow-r/constructors';
+import { andThen, map } from '@konker.dev/neverthrow-r/sync';
+import { pipe } from '@konker.dev/neverthrow-r/pipe';
+import { provide } from '@konker.dev/neverthrow-r/provide';
+import type { ResultR } from '@konker.dev/neverthrow-r/types';
+
+type WithMultiplier = { multiplier: number };
+
+const scaled = (n: number): ResultR<WithMultiplier, number, never> =>
+  (r) => okR<number>(n * r.multiplier)(undefined);
+
+const program = pipe(
+  okR<number>(2),
+  map((n) => n + 1),
+  andThen(scaled),
+);
+
+provide(program, { multiplier: 10 }); // Ok(30)
+```
 
 ## Type Aliases
 

--- a/packages/neverthrow-r/docs/reference/types/type-aliases/ExtendedScope.md
+++ b/packages/neverthrow-r/docs/reference/types/type-aliases/ExtendedScope.md
@@ -2,13 +2,16 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [types](../README.md) / ExtendedScope
+[@konker.dev/neverthrow-r](../../modules.md) / [types](../README.md) / ExtendedScope
 
 # Type Alias: ExtendedScope\<S, N, A\>
 
 > **ExtendedScope**\<`S`, `N`, `A`\> = `S` *extends* `unknown` ? \{ \[K in keyof S \| N\]: K extends N ? A : K extends keyof S ? S\[K\] : never \} : `never`
 
-Defined in: [types.ts:20](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/types.ts#L20)
+Defined in: [types.ts:172](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/types.ts#L172)
+
+Adds a typed field `N: A` to an existing scope `S`, preserving the existing
+fields' types. Distributive over unions in `S`.
 
 ## Type Parameters
 
@@ -16,10 +19,36 @@ Defined in: [types.ts:20](https://github.com/konker/konker.dev/blob/main/package
 
 `S` *extends* `object`
 
+The existing scope record.
+
 ### N
 
 `N` *extends* `string`
 
+The string-literal name of the field being added.
+
 ### A
 
 `A`
+
+The type of the newly bound value.
+
+## Remarks
+
+This is the type-level operation behind bindR: it computes the
+record shape *after* a new field has been bound, with the new field's type
+`A` slotted in and existing fields untouched.
+
+## Example
+
+```ts
+import type { ExtendedScope } from '@konker.dev/neverthrow-r/types';
+
+type S0 = { user: { id: number } };
+type S1 = ExtendedScope<S0, 'role', 'admin' | 'guest'>;
+// { user: { id: number }; role: 'admin' | 'guest' }
+```
+
+## See
+
+bindR

--- a/packages/neverthrow-r/docs/reference/types/type-aliases/ResultAsyncR.md
+++ b/packages/neverthrow-r/docs/reference/types/type-aliases/ResultAsyncR.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [types](../README.md) / ResultAsyncR
+[@konker.dev/neverthrow-r](../../modules.md) / [types](../README.md) / ResultAsyncR
 
 # Type Alias: ResultAsyncR()\<R, T, E\>
 
 > **ResultAsyncR**\<`R`, `T`, `E`\> = (`r`) => `ResultAsync`\<`T`, `E`\>
 
-Defined in: [types.ts:14](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/types.ts#L14)
+Defined in: [types.ts:105](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/types.ts#L105)
+
+A `ResultAsync<T, E>` that requires an environment `R` to produce.
 
 ## Type Parameters
 
@@ -16,13 +18,19 @@ Defined in: [types.ts:14](https://github.com/konker/konker.dev/blob/main/package
 
 `R`
 
+The requirements (environment) the value depends on.
+
 ### T
 
 `T`
 
+The success type.
+
 ### E
 
 `E`
+
+The error type.
 
 ## Parameters
 
@@ -33,3 +41,24 @@ Defined in: [types.ts:14](https://github.com/konker/konker.dev/blob/main/package
 ## Returns
 
 `ResultAsync`\<`T`, `E`\>
+
+## Remarks
+
+The async sibling of [ResultR](ResultR.md). Structurally `(r: R) => ResultAsync<T, E>`.
+Combine sync and async values in one pipeline via the [bridges](../../bridges/README.md) module.
+
+## Example
+
+```ts
+import type { ResultAsyncR } from '@konker.dev/neverthrow-r/types';
+import { okAsync } from 'neverthrow';
+
+type Deps = { fetch: (url: string) => Promise<unknown> };
+
+const fetchJson: (url: string) => ResultAsyncR<Deps, unknown, never> =
+  (url) => (r) => okAsync(undefined).map(() => r.fetch(url));
+```
+
+## See
+
+[ResultR](ResultR.md) for the sync version.

--- a/packages/neverthrow-r/docs/reference/types/type-aliases/ResultR.md
+++ b/packages/neverthrow-r/docs/reference/types/type-aliases/ResultR.md
@@ -2,13 +2,15 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [types](../README.md) / ResultR
+[@konker.dev/neverthrow-r](../../modules.md) / [types](../README.md) / ResultR
 
 # Type Alias: ResultR()\<R, T, E\>
 
 > **ResultR**\<`R`, `T`, `E`\> = (`r`) => `Result`\<`T`, `E`\>
 
-Defined in: [types.ts:13](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/types.ts#L13)
+Defined in: [types.ts:79](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/types.ts#L79)
+
+A `Result<T, E>` that requires an environment `R` to produce.
 
 ## Type Parameters
 
@@ -16,13 +18,19 @@ Defined in: [types.ts:13](https://github.com/konker/konker.dev/blob/main/package
 
 `R`
 
+The requirements (environment) the value depends on.
+
 ### T
 
 `T`
 
+The success type.
+
 ### E
 
 `E`
+
+The error type.
 
 ## Parameters
 
@@ -33,3 +41,33 @@ Defined in: [types.ts:13](https://github.com/konker/konker.dev/blob/main/package
 ## Returns
 
 `Result`\<`T`, `E`\>
+
+## Remarks
+
+`ResultR<R, T, E>` is structurally `(r: R) => Result<T, E>`. The `R` channel
+is the third dimension this package adds on top of `neverthrow`: it makes
+dependencies (database handles, config, clocks, …) explicit in the type
+rather than implicit in the closure.
+
+Use `unknown` for `R` when no environment is required (most often via the
+default on constructors like okR).
+
+Composition operators in [sync](../../sync/README.md) and [do](../../do/README.md) intersect `R` across
+steps, so `R1 & R2 & R3` falls out of `andThen`-style chains automatically.
+
+## Example
+
+```ts
+import type { ResultR } from '@konker.dev/neverthrow-r/types';
+import { ok } from 'neverthrow';
+
+type Deps = { now: () => Date };
+
+const currentYear: ResultR<Deps, number, never> =
+  (r) => ok(r.now().getFullYear());
+```
+
+## See
+
+ - [ResultAsyncR](ResultAsyncR.md) for the async sibling.
+ - [provide](../../provide/README.md) for supplying the environment.

--- a/packages/neverthrow-r/docs/reference/types/type-aliases/Scope.md
+++ b/packages/neverthrow-r/docs/reference/types/type-aliases/Scope.md
@@ -2,16 +2,35 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [types](../README.md) / Scope
+[@konker.dev/neverthrow-r](../../modules.md) / [types](../README.md) / Scope
 
 # Type Alias: Scope\<Keys\>
 
 > **Scope**\<`Keys`\> = `Record`\<`Keys`, `unknown`\>
 
-Defined in: [types.ts:18](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/types.ts#L18)
+Defined in: [types.ts:146](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/types.ts#L146)
+
+A record-shaped scope keyed by string field names, used by do-notation to
+accumulate intermediate values across a chain of `bindR` / `bindAsyncR`
+steps.
 
 ## Type Parameters
 
 ### Keys
 
 `Keys` *extends* `string`
+
+The union of string keys currently in the scope.
+
+## Example
+
+```ts
+import type { Scope } from '@konker.dev/neverthrow-r/types';
+
+type S = Scope<'user' | 'config'>;
+// { user: unknown; config: unknown }
+```
+
+## See
+
+[ExtendedScope](ExtendedScope.md) for the type-level "add a field" operation.

--- a/packages/neverthrow-r/docs/reference/types/type-aliases/Simplify.md
+++ b/packages/neverthrow-r/docs/reference/types/type-aliases/Simplify.md
@@ -2,16 +2,37 @@
 
 ***
 
-[@konker.dev/neverthrow-r](../../README.md) / [types](../README.md) / Simplify
+[@konker.dev/neverthrow-r](../../modules.md) / [types](../README.md) / Simplify
 
 # Type Alias: Simplify\<T\>
 
 > **Simplify**\<`T`\> = `{ [K in keyof T]: T[K] }` & `object`
 
-Defined in: [types.ts:16](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/types.ts#L16)
+Defined in: [types.ts:127](https://github.com/konker/konker.dev/blob/main/packages/neverthrow-r/src/types.ts#L127)
+
+Flattens an intersection type into a single record so it renders nicely in
+inferred type displays and tooltips.
 
 ## Type Parameters
 
 ### T
 
 `T`
+
+The type to flatten.
+
+## Remarks
+
+Used internally where a chain has accumulated `R1 & R2 & R3 & …` and a
+cleaner display is desired (e.g. provideSome's return type). Has no
+runtime effect.
+
+## Example
+
+```ts
+import type { Simplify } from '@konker.dev/neverthrow-r/types';
+
+type A = { a: number };
+type B = { b: string };
+type Combined = Simplify<A & B>; // { a: number; b: string }
+```

--- a/packages/neverthrow-r/eslint.config.mjs
+++ b/packages/neverthrow-r/eslint.config.mjs
@@ -3,6 +3,9 @@ import baseConfig from '@konker.dev/common-config/configs/eslint.config-base.mjs
 export default [
   ...baseConfig,
   {
+    ignores: ['.examples-check/**'],
+  },
+  {
     ignores: ['vitest.config.ts'],
     languageOptions: {
       parserOptions: {

--- a/packages/neverthrow-r/package.json
+++ b/packages/neverthrow-r/package.json
@@ -102,6 +102,7 @@
     "generated-exports-check": "npx --package=@konker.dev/common-config generate-exports-verify `pwd`",
     "docs-generate": "typedoc",
     "generated-docs-check": "pnpm run docs-generate && git diff --exit-code docs/reference",
+    "examples-check": "node scripts/check-examples.mjs",
     "exports-check": "NPM_CONFIG_CACHE=.npm-cache attw --pack . --ignore-rules=cjs-resolves-to-esm --profile=esm-only",
     "fixme-check": "leasot --exit-nicely --skip-unsupported src",
     "prettier-check": "npx prettier --check --ignore-path .gitignore --ignore-path .prettierignore '**/*.{css,html,js,ts,json,md,yaml,yml}'",
@@ -110,7 +111,7 @@
     "lint-fix": "pnpm run eslint-fix && pnpm run prettier-fix",
     "pre-push": "pnpm run lint-check && pnpm run typecheck",
     "codecov": "npx --package=@konker.dev/common-config codecov-upload `pwd` '@konker.dev/neverthrow-r'",
-    "ci": "pnpm run lint-check && pnpm run typecheck && pnpm run type-coverage-check && pnpm run test && pnpm run build && pnpm run generated-exports-check && pnpm run generated-docs-check && pnpm run exports-check && pnpm run fixme-check",
+    "ci": "pnpm run lint-check && pnpm run typecheck && pnpm run type-coverage-check && pnpm run test && pnpm run build && pnpm run generated-exports-check && pnpm run generated-docs-check && pnpm run examples-check && pnpm run exports-check && pnpm run fixme-check",
     "cd": "pnpm run build && npx --package=@konker.dev/common-config npm-publish-if-version-not-exists `pwd`"
   }
 }

--- a/packages/neverthrow-r/scripts/check-examples.mjs
+++ b/packages/neverthrow-r/scripts/check-examples.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Extracts ```ts / ```typescript fences from JSDoc @example blocks in src/*.ts,
+// writes each to .examples-check/<module>-<n>.ts, and runs tsc --noEmit.
+
+import { execSync } from 'node:child_process';
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, '..');
+const srcDir = join(pkgRoot, 'src');
+const outDir = join(pkgRoot, '.examples-check');
+
+rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+const sourceFiles = readdirSync(srcDir)
+  .filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'));
+
+const JSDOC = /\/\*\*([\s\S]*?)\*\//g;
+// After stripping the leading " * " line prefixes, an @example block runs from
+// the @example tag's line until the next @-tag at line start (or end of body).
+const EXAMPLE_FENCE = /^@example[^\n]*\n([\s\S]*?)(?=^@\w|\Z)/gm;
+const CODE_FENCE = /```(?:ts|typescript)\s*\n([\s\S]*?)```/g;
+
+let total = 0;
+for (const file of sourceFiles) {
+  const moduleName = file.replace(/\.ts$/, '');
+  const text = readFileSync(join(srcDir, file), 'utf8');
+  let n = 0;
+  for (const [, body] of text.matchAll(JSDOC)) {
+    // Strip leading " * " from each line of the JSDoc body.
+    const stripped = body.replace(/^[ \t]*\*[ \t]?/gm, '');
+    for (const [, exampleBody] of stripped.matchAll(EXAMPLE_FENCE)) {
+      for (const [, code] of exampleBody.matchAll(CODE_FENCE)) {
+        const outFile = join(outDir, `${moduleName}-${n}.ts`);
+        writeFileSync(outFile, code);
+        n += 1;
+        total += 1;
+      }
+    }
+  }
+}
+
+if (total === 0) {
+  console.log('check-examples: no @example fences found, skipping tsc.');
+  process.exit(0);
+}
+
+console.log(`check-examples: extracted ${total} example(s), running tsc...`);
+try {
+  execSync('npx tsc -p tsconfig.examples.json', {
+    cwd: pkgRoot,
+    stdio: 'inherit',
+  });
+  console.log('check-examples: OK');
+} catch {
+  console.error('check-examples: FAILED');
+  process.exit(1);
+}

--- a/packages/neverthrow-r/src/async.ts
+++ b/packages/neverthrow-r/src/async.ts
@@ -1,57 +1,217 @@
 /**
- * Async operators over `ResultAsyncR`: `mapAsync`, `mapErrAsync`,
- * `andThenAsync`, `orElseAsync`, `matchAsync`, `andTeeAsync`, `orTeeAsync`,
- * `andThroughAsync`. Mirror the sync surface from `./sync`, suffixed with
- * `Async` to avoid barrel collisions, and delegate to the corresponding
- * neverthrow `ResultAsync` methods.
+ * Async combinators over `ResultAsyncR`, mirroring the sync surface from
+ * {@link sync} 1:1. Each combinator is the `Async`-suffixed sibling of its
+ * sync counterpart; semantics and type signatures match, lifted to
+ * `ResultAsyncR`.
+ *
+ * @remarks
+ * Cross-link to the sync module for the full prose on each combinator. The
+ * docs here focus on the async-specific shape: each transformer accepts
+ * `Promise`-returning functions, and the operand is a `ResultAsyncR`.
+ *
+ * Reach for this module when the chain is already async (e.g. it started
+ * with {@link okAsyncR} or was promoted via {@link bridges}). To enter the
+ * async track from a sync chain mid-pipeline, use {@link bridges} instead.
+ *
+ * @example
+ * ```ts
+ * import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andThenAsync, mapAsync } from '@konker.dev/neverthrow-r/async';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const program = pipe(
+ *   okAsyncR<number>(2),
+ *   mapAsync(async (n) => n + 1),
+ *   andThenAsync((n) => okAsyncR<string>(`got ${n}`)),
+ * );
+ *
+ * program(undefined); // ResultAsync resolving to Ok('got 3')
+ * ```
  *
  * @module
  */
 
 import type { ResultAsyncR } from './types.js';
 
+/**
+ * Async variant of {@link map}. Accepts a sync- or `Promise`-returning
+ * transform.
+ *
+ * @example
+ * ```ts
+ * import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { mapAsync } from '@konker.dev/neverthrow-r/async';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const doubled = pipe(okAsyncR<number>(2), mapAsync(async (n) => n * 2));
+ * ```
+ *
+ * @see {@link map}
+ */
 export const mapAsync =
   <A, B>(f: (a: A) => B | Promise<B>) =>
   <R, E>(rr: ResultAsyncR<R, A, E>): ResultAsyncR<R, B, E> =>
   (r) =>
     rr(r).map(f);
 
+/**
+ * Async variant of {@link mapErr}. Accepts a sync- or `Promise`-returning
+ * transform.
+ *
+ * @example
+ * ```ts
+ * import { errAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { mapErrAsync } from '@konker.dev/neverthrow-r/async';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const wrapped = pipe(
+ *   errAsyncR<string>('boom'),
+ *   mapErrAsync(async (msg) => ({ tag: 'fail' as const, msg })),
+ * );
+ * ```
+ *
+ * @see {@link mapErr}
+ */
 export const mapErrAsync =
   <E, F>(f: (e: E) => F | Promise<F>) =>
   <R, T>(rr: ResultAsyncR<R, T, E>): ResultAsyncR<R, T, F> =>
   (r) =>
     rr(r).mapErr(f);
 
+/**
+ * Async variant of {@link andThen}. The continuation returns a
+ * `ResultAsyncR`; its requirements intersect into the chain.
+ *
+ * @example
+ * ```ts
+ * import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andThenAsync } from '@konker.dev/neverthrow-r/async';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const program = pipe(
+ *   okAsyncR<number>(2),
+ *   andThenAsync((n) => okAsyncR<string>(`got ${n}`)),
+ * );
+ * ```
+ *
+ * @see {@link andThen}
+ */
 export const andThenAsync =
   <A, R2, B, E2>(f: (a: A) => ResultAsyncR<R2, B, E2>) =>
   <R1, E1>(rr: ResultAsyncR<R1, A, E1>): ResultAsyncR<R1 & R2, B, E1 | E2> =>
   (r) =>
     rr(r).andThen((a) => f(a)(r));
 
+/**
+ * Async variant of {@link orElse}. The recovery returns a `ResultAsyncR`.
+ *
+ * @example
+ * ```ts
+ * import { errAsyncR, okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { orElseAsync } from '@konker.dev/neverthrow-r/async';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const withFallback = pipe(
+ *   errAsyncR<string, number>('boom'),
+ *   orElseAsync(() => okAsyncR<number>(0)),
+ * );
+ * ```
+ *
+ * @see {@link orElse}
+ */
 export const orElseAsync =
   <E, R2, U, F>(f: (e: E) => ResultAsyncR<R2, U, F>) =>
   <R1, T>(rr: ResultAsyncR<R1, T, E>): ResultAsyncR<R1 & R2, T | U, F> =>
   (r) =>
     rr(r).orElse((e) => f(e)(r));
 
+/**
+ * Async variant of {@link match}. Returns a function from environment to a
+ * `Promise` of the matched value.
+ *
+ * @example
+ * ```ts
+ * import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { matchAsync } from '@konker.dev/neverthrow-r/async';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const rendered = pipe(
+ *   okAsyncR<number>(42),
+ *   matchAsync(
+ *     (n) => `got ${n}`,
+ *     (e: never) => `error: ${String(e)}`,
+ *   ),
+ * );
+ * // rendered(undefined) is Promise<string>
+ * ```
+ *
+ * @see {@link match}
+ */
 export const matchAsync =
   <T, E, A, B = A>(okFn: (t: T) => A, errFn: (e: E) => B) =>
   <R>(rr: ResultAsyncR<R, T, E>) =>
   async (r: R): Promise<A | B> =>
     rr(r).match(okFn, errFn);
 
+/**
+ * Async variant of {@link andTee}.
+ *
+ * @example
+ * ```ts
+ * import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andTeeAsync } from '@konker.dev/neverthrow-r/async';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const traced = pipe(okAsyncR<number>(2), andTeeAsync((n) => console.log(n)));
+ * ```
+ *
+ * @see {@link andTee}
+ */
 export const andTeeAsync =
   <T>(f: (t: T) => unknown) =>
   <R, E>(rr: ResultAsyncR<R, T, E>): ResultAsyncR<R, T, E> =>
   (r) =>
     rr(r).andTee(f);
 
+/**
+ * Async variant of {@link orTee}.
+ *
+ * @example
+ * ```ts
+ * import { errAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { orTeeAsync } from '@konker.dev/neverthrow-r/async';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const logged = pipe(errAsyncR<string>('boom'), orTeeAsync((e) => console.error(e)));
+ * ```
+ *
+ * @see {@link orTee}
+ */
 export const orTeeAsync =
   <E>(f: (e: E) => unknown) =>
   <R, T>(rr: ResultAsyncR<R, T, E>): ResultAsyncR<R, T, E> =>
   (r) =>
     rr(r).orTee(f);
 
+/**
+ * Async variant of {@link andThrough}.
+ *
+ * @example
+ * ```ts
+ * import { errAsyncR, okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andThroughAsync } from '@konker.dev/neverthrow-r/async';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const validated = pipe(
+ *   okAsyncR<number>(2),
+ *   andThroughAsync((n) =>
+ *     n > 0 ? okAsyncR<unknown>(undefined) : errAsyncR<string>('non-positive'),
+ *   ),
+ * );
+ * ```
+ *
+ * @see {@link andThrough}
+ */
 export const andThroughAsync =
   <T, R2, F>(f: (t: T) => ResultAsyncR<R2, unknown, F>) =>
   <R1, E>(rr: ResultAsyncR<R1, T, E>): ResultAsyncR<R1 & R2, T, E | F> =>

--- a/packages/neverthrow-r/src/bridges.ts
+++ b/packages/neverthrow-r/src/bridges.ts
@@ -1,26 +1,145 @@
 /**
- * Sync→async bridge operators that take a `ResultR` and return a
- * `ResultAsyncR`: `asyncMap`, `asyncAndThen`, `asyncAndThrough`. They follow
- * the same `R1 & R2` intersection rule as the pure sync/async operators,
- * promoting the chain to the async track.
+ * Sync→async bridge operators: take a `ResultR` and return a `ResultAsyncR`,
+ * promoting the chain onto the async track mid-pipeline.
+ *
+ * @remarks
+ * Reach for this module when a chain that starts synchronously needs to
+ * await — typically an I/O call partway through. Three flavours, mirroring
+ * the corresponding sync combinators but lifting the operand into
+ * `ResultAsyncR`:
+ *
+ * - {@link asyncMap} — promote via a `Promise`-returning transform.
+ * - {@link asyncAndThen} — promote via a `ResultAsyncR`-returning step.
+ * - {@link asyncAndThrough} — promote via a fallible async tee.
+ *
+ * Every step *after* the bridge must come from {@link async} (the
+ * `*Async`-suffixed combinators); there is no async→sync bridge.
+ *
+ * @example
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { mapAsync } from '@konker.dev/neverthrow-r/async';
+ * import { asyncMap } from '@konker.dev/neverthrow-r/bridges';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const program = pipe(
+ *   okR<number>(2),
+ *   asyncMap(async (n) => n + 1),   // sync → async here
+ *   mapAsync(async (n) => n * 10),  // continue async
+ * );
+ *
+ * program(undefined); // ResultAsync resolving to Ok(30)
+ * ```
  *
  * @module
  */
 
 import type { ResultAsyncR, ResultR } from './types.js';
 
+/**
+ * Promotes a `ResultR` to a `ResultAsyncR` by applying a `Promise`-returning
+ * transform to the success value.
+ *
+ * @remarks
+ * The sync→async sibling of {@link map}. After this step the chain is async;
+ * follow with {@link mapAsync}, {@link andThenAsync}, etc.
+ *
+ * @typeParam A - The input success type.
+ * @typeParam B - The output success type.
+ *
+ * @param f - `Promise`-returning transform from `A` to `B`.
+ *
+ * @example
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { asyncMap } from '@konker.dev/neverthrow-r/bridges';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const program = pipe(okR<number>(2), asyncMap(async (n) => n * 2));
+ * program(undefined); // ResultAsync resolving to Ok(4)
+ * ```
+ *
+ * @see {@link map}
+ * @see {@link mapAsync}
+ */
 export const asyncMap =
   <A, B>(f: (a: A) => Promise<B>) =>
   <R, E>(rr: ResultR<R, A, E>): ResultAsyncR<R, B, E> =>
   (r) =>
     rr(r).asyncMap(f);
 
+/**
+ * Promotes a `ResultR` to a `ResultAsyncR` by chaining a
+ * `ResultAsyncR`-returning step.
+ *
+ * @remarks
+ * Sync→async sibling of {@link andThen}. The continuation's requirements
+ * `R2` are intersected (`R1 & R2`); its error type `E2` is unioned
+ * (`E1 | E2`).
+ *
+ * @typeParam A - The previous step's success type.
+ * @typeParam R2 - The continuation's requirements.
+ * @typeParam B - The continuation's success type.
+ * @typeParam E2 - The continuation's error type.
+ *
+ * @param f - Function from the previous success value to a `ResultAsyncR`.
+ *
+ * @example
+ * ```ts
+ * import { okAsyncR, okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { asyncAndThen } from '@konker.dev/neverthrow-r/bridges';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const program = pipe(
+ *   okR<number>(2),
+ *   asyncAndThen((n) => okAsyncR<string>(`got ${n}`)),
+ * );
+ *
+ * program(undefined); // ResultAsync resolving to Ok('got 2')
+ * ```
+ *
+ * @see {@link andThen}
+ * @see {@link andThenAsync}
+ */
 export const asyncAndThen =
   <A, R2, B, E2>(f: (a: A) => ResultAsyncR<R2, B, E2>) =>
   <R1, E1>(rr: ResultR<R1, A, E1>): ResultAsyncR<R1 & R2, B, E1 | E2> =>
   (r) =>
     rr(r).asyncAndThen((a) => f(a)(r));
 
+/**
+ * Promotes a `ResultR` to a `ResultAsyncR` via a fallible async tee that
+ * propagates the *original* success value.
+ *
+ * @remarks
+ * Sync→async sibling of {@link andThrough}. The tee step is itself a
+ * `ResultAsyncR` that can fail; on success its value is discarded and the
+ * chain continues with the original success value.
+ *
+ * @typeParam T - The success type (preserved through the step on success).
+ * @typeParam R2 - The tee's requirements.
+ * @typeParam F - The tee's error type.
+ *
+ * @param f - Function from the success value to a `ResultAsyncR` whose value
+ *   is ignored on success.
+ *
+ * @example
+ * ```ts
+ * import { okAsyncR, okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { asyncAndThrough } from '@konker.dev/neverthrow-r/bridges';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const program = pipe(
+ *   okR<number>(2),
+ *   asyncAndThrough((n) => okAsyncR<unknown>(`logged ${n}`)),
+ * );
+ *
+ * program(undefined); // ResultAsync resolving to Ok(2)
+ * ```
+ *
+ * @see {@link andThrough}
+ * @see {@link andThroughAsync}
+ */
 export const asyncAndThrough =
   <T, R2, F>(f: (t: T) => ResultAsyncR<R2, unknown, F>) =>
   <R1, E>(rr: ResultR<R1, T, E>): ResultAsyncR<R1 & R2, T, E | F> =>

--- a/packages/neverthrow-r/src/constructors.ts
+++ b/packages/neverthrow-r/src/constructors.ts
@@ -1,8 +1,36 @@
 /**
- * Constructors and lifters that produce `ResultR` / `ResultAsyncR` values:
- * `okR`, `errR`, `okAsyncR`, `errAsyncR` for plain values; `fromResult` and
- * `fromResultAsync` for lifting existing neverthrow values; `asks` and `ask`
- * for building a `ResultR` directly from the environment.
+ * Entry points for building `ResultR` / `ResultAsyncR` values from scratch or
+ * from existing `neverthrow` values. Use these where a pipeline starts.
+ *
+ * @remarks
+ * - {@link okR} / {@link errR} / {@link okAsyncR} / {@link errAsyncR} — lift a
+ *   plain value (or error) into a `ResultR` / `ResultAsyncR` with no
+ *   requirements (`R = unknown`).
+ * - {@link fromResult} / {@link fromResultAsync} — lift an existing neverthrow
+ *   `Result` / `ResultAsync` into the `R`-channel layer with no requirements.
+ * - {@link asks} / {@link ask} — build a `ResultR` whose only effect is to
+ *   read from the environment, declaring `R` in the process.
+ *
+ * Any non-trivial requirements (a database handle, a clock, …) are introduced
+ * with `asks`; the rest of the pipeline picks them up via intersection in
+ * `andThen`-style operators.
+ *
+ * @example
+ * ```ts
+ * import { asks, okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andThen, map } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * type Clock = { now: () => Date };
+ *
+ * const year = asks((r: Clock) => r.now().getFullYear());
+ *
+ * const program = pipe(
+ *   okR<number>(2024),
+ *   map((n) => n + 1),
+ *   andThen(() => year),
+ * );
+ * ```
  *
  * @module
  */
@@ -12,39 +40,206 @@ import { err, errAsync, ok, okAsync } from 'neverthrow';
 
 import type { ResultAsyncR, ResultR } from './types.js';
 
+/**
+ * Lifts a plain success value into a `ResultR` with no requirements.
+ *
+ * @remarks
+ * Equivalent to `() => ok(value)`. The `R` parameter defaults to `unknown`
+ * because the constructor doesn't read from the environment.
+ *
+ * @typeParam T - The success type.
+ * @typeParam E - The error type (defaults to `never` since this always
+ *   succeeds).
+ *
+ * @param value - The value to wrap in an `Ok`.
+ * @returns A `ResultR<unknown, T, E>` that ignores its environment and yields
+ *   `Ok(value)`.
+ *
+ * @example
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ *
+ * const two = okR<number>(2);
+ * two(undefined); // Ok(2)
+ * ```
+ *
+ * @see {@link errR}
+ * @see {@link okAsyncR}
+ */
 export const okR =
   <T, E = never>(value: T): ResultR<unknown, T, E> =>
   () =>
     ok(value);
 
+/**
+ * Lifts a plain error value into a `ResultR` with no requirements.
+ *
+ * @typeParam E - The error type.
+ * @typeParam T - The success type (defaults to `never` since this always
+ *   fails).
+ *
+ * @param error - The error value to wrap in an `Err`.
+ *
+ * @example
+ * ```ts
+ * import { errR } from '@konker.dev/neverthrow-r/constructors';
+ *
+ * const fail = errR<string>('boom');
+ * fail(undefined); // Err('boom')
+ * ```
+ *
+ * @see {@link okR}
+ * @see {@link errAsyncR}
+ */
 export const errR =
   <E, T = never>(error: E): ResultR<unknown, T, E> =>
   () =>
     err(error);
 
+/**
+ * Async sibling of {@link okR}: lifts a plain success value into a
+ * `ResultAsyncR` with no requirements.
+ *
+ * @example
+ * ```ts
+ * import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ *
+ * const program = okAsyncR<number>(2);
+ * program(undefined); // ResultAsync resolving to Ok(2)
+ * ```
+ *
+ * @see {@link okR}
+ */
 export const okAsyncR =
   <T, E = never>(value: T): ResultAsyncR<unknown, T, E> =>
   () =>
     okAsync(value);
 
+/**
+ * Async sibling of {@link errR}: lifts a plain error value into a
+ * `ResultAsyncR` with no requirements.
+ *
+ * @example
+ * ```ts
+ * import { errAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ *
+ * const fail = errAsyncR<string>('boom');
+ * fail(undefined); // ResultAsync resolving to Err('boom')
+ * ```
+ *
+ * @see {@link errR}
+ */
 export const errAsyncR =
   <E, T = never>(error: E): ResultAsyncR<unknown, T, E> =>
   () =>
     errAsync(error);
 
+/**
+ * Lifts an existing neverthrow `Result<T, E>` into a `ResultR<unknown, T, E>`.
+ *
+ * @remarks
+ * Useful at the seam where existing neverthrow-using code is being adapted
+ * into a pipeline that wants the `R` channel — wrap the legacy value once and
+ * compose normally thereafter.
+ *
+ * @typeParam T - The success type.
+ * @typeParam E - The error type.
+ *
+ * @param r - The existing `Result` to lift.
+ *
+ * @example
+ * ```ts
+ * import { ok } from 'neverthrow';
+ * import { fromResult } from '@konker.dev/neverthrow-r/constructors';
+ *
+ * const existing = ok<number, string>(42);
+ * const lifted = fromResult(existing);
+ * lifted(undefined); // Ok(42)
+ * ```
+ *
+ * @see {@link fromResultAsync}
+ */
 export const fromResult =
   <T, E>(r: Result<T, E>): ResultR<unknown, T, E> =>
   () =>
     r;
 
+/**
+ * Async sibling of {@link fromResult}: lifts an existing `ResultAsync<T, E>`
+ * into a `ResultAsyncR<unknown, T, E>`.
+ *
+ * @example
+ * ```ts
+ * import { okAsync } from 'neverthrow';
+ * import { fromResultAsync } from '@konker.dev/neverthrow-r/constructors';
+ *
+ * const existing = okAsync<number, string>(42);
+ * const lifted = fromResultAsync(existing);
+ * lifted(undefined); // ResultAsync resolving to Ok(42)
+ * ```
+ *
+ * @see {@link fromResult}
+ */
 export const fromResultAsync =
   <T, E>(ra: ResultAsync<T, E>): ResultAsyncR<unknown, T, E> =>
   () =>
     ra;
 
+/**
+ * Builds a `ResultR` whose value is computed from the environment. This is
+ * how requirements are *introduced* into a chain.
+ *
+ * @remarks
+ * `asks(f)` is equivalent to `(r) => ok(f(r))`. The argument's parameter type
+ * fixes the `R` channel for the rest of the pipeline; downstream operators
+ * intersect any further requirements.
+ *
+ * Use this when a step depends on something in the environment (a config
+ * value, a service handle, the current time). For just reading the entire
+ * environment unchanged, see {@link ask}.
+ *
+ * @typeParam R - The requirements (environment) read from.
+ * @typeParam A - The value computed from the environment.
+ *
+ * @param f - A pure function from environment to value.
+ *
+ * @example
+ * ```ts
+ * import { asks } from '@konker.dev/neverthrow-r/constructors';
+ *
+ * type Config = { multiplier: number };
+ *
+ * const multiplier = asks((r: Config) => r.multiplier);
+ * multiplier({ multiplier: 10 }); // Ok(10)
+ * ```
+ *
+ * @see {@link ask}
+ */
 export const asks =
   <R, A>(f: (r: R) => A): ResultR<R, A, never> =>
   (r) =>
     ok(f(r));
 
+/**
+ * Reads the entire environment as the success value.
+ *
+ * @remarks
+ * Specialisation of {@link asks} with the identity function. Most useful when
+ * a step wants the whole environment passed downstream — e.g. to forward it
+ * into a sub-pipeline.
+ *
+ * @typeParam R - The requirements (environment), surfaced as the success type.
+ *
+ * @example
+ * ```ts
+ * import { ask } from '@konker.dev/neverthrow-r/constructors';
+ *
+ * type Config = { multiplier: number };
+ *
+ * const env = ask<Config>();
+ * env({ multiplier: 10 }); // Ok({ multiplier: 10 })
+ * ```
+ *
+ * @see {@link asks}
+ */
 export const ask = <R>(): ResultR<R, R, never> => asks((r: R) => r);

--- a/packages/neverthrow-r/src/do.ts
+++ b/packages/neverthrow-r/src/do.ts
@@ -1,9 +1,37 @@
 /**
- * `bind`-style do-notation for sequentially composing chains that accumulate
- * intermediate values into a record-shaped "scope" while threading `R`.
- * `doR` / `doAsyncR` seed an empty scope; `bindR` / `bindAsyncR` add a named
- * field, intersect the step's `R2` into the chain's requirements, and union
- * its error type. Ergonomic replacement for a generator-based `safeTry`.
+ * Do-notation for `ResultR` / `ResultAsyncR`: chain steps that each bind a
+ * value into a named scope, with the scope record carried through the chain
+ * as the success type.
+ *
+ * @remarks
+ * Two pairs of helpers:
+ *
+ * - {@link doR} / {@link doAsyncR} — seed a chain with an empty scope `{}`.
+ * - {@link bindR} / {@link bindAsyncR} — add a named field by running a step
+ *   that depends on the current scope, then attaching its result under a key.
+ *
+ * Use this in place of nested {@link andThen} when several intermediate
+ * values are needed downstream. Requirements `R` intersect across steps; the
+ * error channel unions; the success record grows with each `bind*`.
+ *
+ * @example
+ * ```ts
+ * import { asks, okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { bindR, doR } from '@konker.dev/neverthrow-r/do';
+ * import { map } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * type Config = { greeting: string };
+ *
+ * const program = pipe(
+ *   doR(),
+ *   bindR('name', () => okR<string>('world')),
+ *   bindR('greeting', () => asks((r: Config) => r.greeting)),
+ *   map(({ greeting, name }) => `${greeting}, ${name}!`),
+ * );
+ *
+ * program({ greeting: 'hello' }); // Ok('hello, world!')
+ * ```
  *
  * @module
  */
@@ -12,22 +40,116 @@ import { ok, okAsync } from 'neverthrow';
 
 import type { ExtendedScope, ResultAsyncR, ResultR } from './types.js';
 
+/**
+ * Seeds a do-chain with an empty scope record `{}` over a `ResultR`.
+ *
+ * @remarks
+ * Pass an explicit type argument when you want to fix the chain's
+ * requirements up front; otherwise leave it as `unknown` and let downstream
+ * {@link bindR} calls accumulate requirements via intersection.
+ *
+ * @typeParam R - The chain's requirements (defaults to `unknown`).
+ *
+ * @example
+ * ```ts
+ * import { doR } from '@konker.dev/neverthrow-r/do';
+ *
+ * const start = doR();
+ * start(undefined); // Ok({})
+ * ```
+ *
+ * @see {@link doAsyncR}
+ * @see {@link bindR}
+ */
 export const doR =
   <R = unknown>(): ResultR<R, Record<never, never>, never> =>
   () =>
     ok({});
 
+/**
+ * Async sibling of {@link doR}: seeds a do-chain with an empty scope over a
+ * `ResultAsyncR`.
+ *
+ * @example
+ * ```ts
+ * import { doAsyncR } from '@konker.dev/neverthrow-r/do';
+ *
+ * const start = doAsyncR();
+ * start(undefined); // ResultAsync resolving to Ok({})
+ * ```
+ *
+ * @see {@link doR}
+ */
 export const doAsyncR =
   <R = unknown>(): ResultAsyncR<R, Record<never, never>, never> =>
   () =>
     okAsync({});
 
+/**
+ * Adds a named field to a do-chain's scope.
+ *
+ * @remarks
+ * `bindR('name', f)` runs `f(scope)` and, on success, attaches its value at
+ * key `name` in the scope record. The step's requirements `R2` are
+ * intersected (`R1 & R2`) and its error type `E2` is unioned (`E1 | E2`).
+ *
+ * The callback receives the *current* scope, so later binds can depend on
+ * earlier ones — a key ergonomic win over a flat sequence of {@link andThen}.
+ *
+ * @typeParam N - The string-literal name of the field being added.
+ * @typeParam S - The current scope record.
+ * @typeParam R2 - The step's requirements.
+ * @typeParam A - The value being bound.
+ * @typeParam E2 - The step's error type.
+ *
+ * @param name - The field name to bind under.
+ * @param f - Function from current scope to the next step's `ResultR`.
+ *
+ * @example
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { bindR, doR } from '@konker.dev/neverthrow-r/do';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const program = pipe(
+ *   doR(),
+ *   bindR('a', () => okR<number>(2)),
+ *   bindR('b', ({ a }) => okR<number>(a * 10)),
+ * );
+ *
+ * program(undefined); // Ok({ a: 2, b: 20 })
+ * ```
+ *
+ * @see {@link bindAsyncR}
+ * @see {@link ExtendedScope}
+ */
 export const bindR =
   <N extends string, S extends object, R2, A, E2>(name: N, f: (s: S) => ResultR<R2, A, E2>) =>
   <R1, E1>(rr: ResultR<R1, S, E1>): ResultR<R1 & R2, ExtendedScope<S, N, A>, E1 | E2> =>
   (r) =>
     rr(r).andThen((s) => f(s)(r).map((a) => ({ ...s, [name]: a }) as ExtendedScope<S, N, A>));
 
+/**
+ * Async sibling of {@link bindR}: adds a named field to an async do-chain's
+ * scope.
+ *
+ * @example
+ * ```ts
+ * import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { bindAsyncR, doAsyncR } from '@konker.dev/neverthrow-r/do';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const program = pipe(
+ *   doAsyncR(),
+ *   bindAsyncR('a', () => okAsyncR<number>(2)),
+ *   bindAsyncR('b', ({ a }) => okAsyncR<number>(a * 10)),
+ * );
+ *
+ * program(undefined); // ResultAsync resolving to Ok({ a: 2, b: 20 })
+ * ```
+ *
+ * @see {@link bindR}
+ */
 export const bindAsyncR =
   <N extends string, S extends object, R2, A, E2>(name: N, f: (s: S) => ResultAsyncR<R2, A, E2>) =>
   <R1, E1>(rr: ResultAsyncR<R1, S, E1>): ResultAsyncR<R1 & R2, ExtendedScope<S, N, A>, E1 | E2> =>

--- a/packages/neverthrow-r/src/index.ts
+++ b/packages/neverthrow-r/src/index.ts
@@ -1,8 +1,32 @@
 /**
- * Public barrel for `@konker.dev/neverthrow-r`: a thin Reader-function layer
- * over neverthrow that adds a third "requirements" channel (`R`) to `Result`
- * and `ResultAsync`. Re-exports every public type, constructor, operator,
- * bridge, do-notation helper, provision function, and `pipe`.
+ * Public barrel for `@konker.dev/neverthrow-r` — a thin Reader-function layer
+ * over `neverthrow` that adds a third *requirements* channel `R` alongside
+ * the usual `T` / `E` of `Result`.
+ *
+ * @remarks
+ * Re-exports every public type, constructor, operator, bridge, do-notation
+ * helper, provision function, and `pipe`. For a guided tour and "pick your
+ * module" table, see the package landing page; for the conceptual model of
+ * the `R` channel, see {@link types}.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   andThen,
+ *   map,
+ *   okR,
+ *   pipe,
+ *   provide,
+ * } from '@konker.dev/neverthrow-r';
+ *
+ * const program = pipe(
+ *   okR<number>(2),
+ *   map((n) => n + 1),
+ *   andThen((n) => okR<string>(`got ${n}`)),
+ * );
+ *
+ * provide(program, undefined); // Ok('got 3')
+ * ```
  *
  * @module
  */

--- a/packages/neverthrow-r/src/pipe.ts
+++ b/packages/neverthrow-r/src/pipe.ts
@@ -1,15 +1,66 @@
 /**
- * Small value-piping `pipe` implementation, applying up to 20 unary
- * functions left-to-right with preserved inferred output types. Bundled so
- * `neverthrow-r` doesn't drag in a heavier fp library purely for `pipe`;
- * operators remain shape-compatible with any external `pipe` consumers
- * already use (`effect`, `fp-ts`, `remeda`, …).
+ * Left-to-right function composition. Bundled so `neverthrow-r` doesn't drag
+ * in a heavier fp library purely for `pipe`; signature is shape-compatible
+ * with the `pipe` used by `effect`, `fp-ts`, `remeda`, and similar.
+ *
+ * @remarks
+ * Every combinator in this package is curried so the operand `ResultR`
+ * arrives last, making `pipe` the natural composition tool: feed the seed
+ * value first, then list the operators in order.
+ *
+ * @example
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andThen, map } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const program = pipe(
+ *   okR<number>(2),
+ *   map((n) => n + 1),
+ *   andThen((n) => okR<string>(`got ${n}`)),
+ * );
+ *
+ * program(undefined); // Ok('got 3')
+ * ```
  *
  * @module
  */
 
 type UnaryFn<A, B> = (value: A) => B;
 
+/**
+ * Applies a chain of unary functions left-to-right to an initial value, with
+ * each function's output type inferred and propagated to the next.
+ *
+ * @remarks
+ * Overloads are provided for chains of 0 up to 20 functions. Past 20 arities,
+ * group functions with an intermediate `pipe(...)` call or extract a
+ * sub-chain into a named function.
+ *
+ * Every {@link sync}, {@link async}, {@link bridges}, and {@link do}
+ * combinator returns a unary function shaped for `pipe`, so the typical
+ * pattern is `pipe(seed, op1, op2, …)`.
+ *
+ * @typeParam A - The initial value's type. Subsequent overloads add type
+ *   parameters for each intermediate output.
+ *
+ * @param value - The initial value.
+ * @returns The final value after all functions have been applied. With no
+ *   functions, the input is returned unchanged.
+ *
+ * @example
+ * ```ts
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const result = pipe(
+ *   2,
+ *   (n) => n + 1,
+ *   (n) => n * 10,
+ *   (n) => `value: ${n}`,
+ * );
+ * // result is 'value: 30'
+ * ```
+ */
 export function pipe<A>(value: A): A;
 export function pipe<A, B>(value: A, ab: UnaryFn<A, B>): B;
 export function pipe<A, B, C>(value: A, ab: UnaryFn<A, B>, bc: UnaryFn<B, C>): C;

--- a/packages/neverthrow-r/src/provide.ts
+++ b/packages/neverthrow-r/src/provide.ts
@@ -1,9 +1,28 @@
 /**
- * Provision: supply the environment to a `ResultR` / `ResultAsyncR` and
- * obtain the underlying neverthrow value. `provide(rr, deps)` is the named
- * alias for `rr(deps)` with explicit type narrowing. `provideSome(rr, p)`
- * whole-replaces a subset of requirement keys and returns a `ResultR` over
- * the remaining ones (no deep merge).
+ * Provision: supply the accumulated requirements `R` to a `ResultR` /
+ * `ResultAsyncR` and exit back into a plain `neverthrow` `Result` /
+ * `ResultAsync`.
+ *
+ * @remarks
+ * The rest of the package builds up an `R` channel through intersection;
+ * this module is where you discharge it. Two flavours:
+ *
+ * - {@link provide} — supply the full environment in one call. Returns the
+ *   underlying `Result` (or `ResultAsync`).
+ * - {@link provideSome} — supply a *subset* of the requirements. Returns a
+ *   new `ResultR` over the keys that remain unsatisfied.
+ *
+ * @example
+ * ```ts
+ * import { asks } from '@konker.dev/neverthrow-r/constructors';
+ * import { provide } from '@konker.dev/neverthrow-r/provide';
+ *
+ * type Deps = { factor: number };
+ *
+ * const program = asks((r: Deps) => r.factor * 2);
+ *
+ * provide(program, { factor: 10 }); // Ok(20)
+ * ```
  *
  * @module
  */
@@ -12,6 +31,44 @@ import type { Result, ResultAsync } from 'neverthrow';
 
 import type { ResultAsyncR, ResultR, Simplify } from './types.js';
 
+/**
+ * Supplies the environment to a `ResultR` (or `ResultAsyncR`) and returns
+ * the underlying neverthrow value.
+ *
+ * @remarks
+ * Equivalent to calling `rr(deps)` directly, but named for intent and
+ * overloaded so the return type tracks whether the input is sync or async.
+ *
+ * Typically the final call in a pipeline: composition builds a `ResultR<R, T,
+ * E>`; `provide` discharges `R`.
+ *
+ * @typeParam R - The requirements being supplied.
+ * @typeParam T - The success type.
+ * @typeParam E - The error type.
+ *
+ * @param rr - The `ResultR` or `ResultAsyncR` to provide for.
+ * @param deps - The environment.
+ *
+ * @example
+ * Sync:
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { provide } from '@konker.dev/neverthrow-r/provide';
+ *
+ * provide(okR<number>(2), undefined); // Ok(2)
+ * ```
+ *
+ * @example
+ * Async:
+ * ```ts
+ * import { okAsyncR } from '@konker.dev/neverthrow-r/constructors';
+ * import { provide } from '@konker.dev/neverthrow-r/provide';
+ *
+ * provide(okAsyncR<number>(2), undefined); // ResultAsync resolving to Ok(2)
+ * ```
+ *
+ * @see {@link provideSome}
+ */
 export function provide<R, T, E>(rr: ResultR<R, T, E>, deps: R): Result<T, E>;
 export function provide<R, T, E>(rr: ResultAsyncR<R, T, E>, deps: R): ResultAsync<T, E>;
 export function provide<R, T, E>(
@@ -21,6 +78,48 @@ export function provide<R, T, E>(
   return rr(deps);
 }
 
+/**
+ * Supplies a *subset* of the requirements, returning a new `ResultR` whose
+ * `R` is narrowed to the remaining keys.
+ *
+ * @remarks
+ * Useful for satisfying part of an environment at one level of an
+ * application (e.g. injecting a config singleton in `main`) while leaving the
+ * rest to be supplied later (e.g. a per-request handle).
+ *
+ * The merge is shallow: `partial` and the runtime `rest` are spread into a
+ * single object, with `partial` taking precedence on conflicting keys. There
+ * is no deep merge — if a requirement value is a nested object, supply the
+ * whole nested object in one call, not in pieces across two `provideSome`s.
+ *
+ * The return type uses {@link Simplify} to flatten `Omit<R, keyof P>` for a
+ * clean inferred display.
+ *
+ * @typeParam R - The full requirements of `rr`.
+ * @typeParam T - The success type.
+ * @typeParam E - The error type.
+ * @typeParam P - The subset of `R` being supplied.
+ *
+ * @param rr - The `ResultR` or `ResultAsyncR` to partially provide for.
+ * @param partial - The subset of requirements to inject now.
+ *
+ * @example
+ * ```ts
+ * import { asks } from '@konker.dev/neverthrow-r/constructors';
+ * import { provide, provideSome } from '@konker.dev/neverthrow-r/provide';
+ *
+ * type Deps = { config: { name: string }; handle: number };
+ *
+ * const program = asks((r: Deps) => `${r.config.name}#${r.handle}`);
+ *
+ * // Pre-inject config; defer handle to later.
+ * const withConfig = provideSome(program, { config: { name: 'svc' } });
+ *
+ * provide(withConfig, { handle: 42 }); // Ok('svc#42')
+ * ```
+ *
+ * @see {@link provide}
+ */
 export function provideSome<R, T, E, P extends Partial<R>>(
   rr: ResultR<R, T, E>,
   partial: P

--- a/packages/neverthrow-r/src/sync.ts
+++ b/packages/neverthrow-r/src/sync.ts
@@ -1,56 +1,355 @@
 /**
- * Sync operators over `ResultR`: `map`, `mapErr`, `andThen`, `orElse`,
- * `match`, `andTee`, `orTee`, `andThrough`. Each is a one-line delegation to
- * the underlying neverthrow `Result` method, threading the environment `r`
- * and intersecting requirement types (`R1 & R2`) across composed steps.
+ * Sync combinators over `ResultR`. This is the canonical surface — the async
+ * module ({@link mapAsync}, {@link andThenAsync}, …) mirrors it 1:1 over
+ * `ResultAsyncR`.
+ *
+ * @remarks
+ * Every combinator is curried so it composes cleanly under {@link pipe}: the
+ * transforming function comes first, then the operand `ResultR`. Each one
+ * delegates to the corresponding neverthrow `Result` method, threading the
+ * environment `r` through and **intersecting** requirements across composed
+ * steps (`R1 & R2`).
+ *
+ * Reach for this module when the whole chain is synchronous. The moment a
+ * step needs to await, switch into {@link bridges} (sync→async one-shot) or
+ * the {@link async} module (already-async chain).
+ *
+ * @example
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andThen, map } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const program = pipe(
+ *   okR<number>(2),
+ *   map((n) => n + 1),
+ *   andThen((n) => okR<string>(`got ${n}`)),
+ * );
+ *
+ * program(undefined); // Ok('got 3')
+ * ```
  *
  * @module
  */
 
 import type { ResultR } from './types.js';
 
+/**
+ * Transforms the success value of a `ResultR` with a pure function.
+ *
+ * @remarks
+ * Threads `R` and `E` through unchanged; only `T` changes. The wrapped
+ * function `f` is not called when the underlying `Result` is an `Err`.
+ *
+ * To transform the error channel instead, see {@link mapErr}. To compose
+ * with another `ResultR`-returning step, use {@link andThen}. For side
+ * effects on the success value without changing it, use {@link andTee}.
+ *
+ * @typeParam A - The input success type.
+ * @typeParam B - The output success type.
+ *
+ * @param f - Pure transformation from `A` to `B`.
+ * @returns A function taking a `ResultR<R, A, E>` and returning a
+ *   `ResultR<R, B, E>`.
+ *
+ * @example
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { map } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const doubled = pipe(okR<number>(2), map((n) => n * 2));
+ * doubled(undefined); // Ok(4)
+ * ```
+ *
+ * @see {@link mapErr}
+ * @see {@link andThen}
+ * @see {@link mapAsync}
+ */
 export const map =
   <A, B>(f: (a: A) => B) =>
   <R, E>(rr: ResultR<R, A, E>): ResultR<R, B, E> =>
   (r) =>
     rr(r).map(f);
 
+/**
+ * Transforms the error value of a `ResultR` with a pure function.
+ *
+ * @remarks
+ * Symmetric to {@link map}, but operates on the `E` channel. `T` and `R` pass
+ * through unchanged. Useful for narrowing a wide error type to a domain-
+ * specific one, or for annotating where in a pipeline an error occurred.
+ *
+ * @typeParam E - The input error type.
+ * @typeParam F - The output error type.
+ *
+ * @param f - Pure transformation from `E` to `F`.
+ *
+ * @example
+ * ```ts
+ * import { errR } from '@konker.dev/neverthrow-r/constructors';
+ * import { mapErr } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const annotated = pipe(
+ *   errR<string>('not found'),
+ *   mapErr((msg) => ({ tag: 'lookup', message: msg })),
+ * );
+ *
+ * annotated(undefined); // Err({ tag: 'lookup', message: 'not found' })
+ * ```
+ *
+ * @see {@link map}
+ * @see {@link mapErrAsync}
+ */
 export const mapErr =
   <E, F>(f: (e: E) => F) =>
   <R, T>(rr: ResultR<R, T, E>): ResultR<R, T, F> =>
   (r) =>
     rr(r).mapErr(f);
 
+/**
+ * Chains another `ResultR`-returning step onto a successful result.
+ *
+ * @remarks
+ * This is the workhorse for sequencing computations that each may fail. The
+ * continuation `f` receives the previous step's success value and returns a
+ * new `ResultR` whose requirements `R2` are **intersected** into the chain
+ * (`R1 & R2`) and whose error type `E2` is **unioned** with the chain's
+ * (`E1 | E2`).
+ *
+ * If the previous step is an `Err`, `f` is not called and the error
+ * propagates.
+ *
+ * For multi-step chains that accumulate intermediate values into a named
+ * scope, prefer the do-notation helpers in {@link do}.
+ *
+ * @typeParam A - The previous step's success type.
+ * @typeParam R2 - The continuation's requirements.
+ * @typeParam B - The continuation's success type.
+ * @typeParam E2 - The continuation's error type.
+ *
+ * @param f - Function from the previous success value to a `ResultR`.
+ * @returns A function taking a `ResultR<R1, A, E1>` and returning a
+ *   `ResultR<R1 & R2, B, E1 | E2>`.
+ *
+ * @example
+ * ```ts
+ * import { asks, okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andThen } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * type Config = { factor: number };
+ *
+ * const program = pipe(
+ *   okR<number>(2),
+ *   andThen((n) => asks((r: Config) => n * r.factor)),
+ * );
+ *
+ * program({ factor: 10 }); // Ok(20)
+ * ```
+ *
+ * @see {@link orElse} for the error-channel mirror.
+ * @see {@link andThrough} for a chain that returns the previous value.
+ * @see {@link andThenAsync}
+ * @see {@link bindR}
+ */
 export const andThen =
   <A, R2, B, E2>(f: (a: A) => ResultR<R2, B, E2>) =>
   <R1, E1>(rr: ResultR<R1, A, E1>): ResultR<R1 & R2, B, E1 | E2> =>
   (r) =>
     rr(r).andThen((a) => f(a)(r));
 
+/**
+ * Recovers from an `Err` by running another `ResultR`-returning step.
+ *
+ * @remarks
+ * The error-channel mirror of {@link andThen}: `f` is called only when the
+ * previous step is an `Err`. The recovery's requirements `R2` are intersected
+ * (`R1 & R2`) and its success type `U` is unioned with the original `T`
+ * (`T | U`). The recovery itself can still fail, with its own error type `F`.
+ *
+ * @typeParam E - The previous step's error type.
+ * @typeParam R2 - The recovery's requirements.
+ * @typeParam U - The recovery's success type.
+ * @typeParam F - The recovery's error type.
+ *
+ * @param f - Function from the previous error to a recovery `ResultR`.
+ *
+ * @example
+ * ```ts
+ * import { errR, okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { orElse } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const withFallback = pipe(
+ *   errR<string, number>('boom'),
+ *   orElse(() => okR<number>(0)),
+ * );
+ *
+ * withFallback(undefined); // Ok(0)
+ * ```
+ *
+ * @see {@link andThen}
+ * @see {@link orElseAsync}
+ */
 export const orElse =
   <E, R2, U, F>(f: (e: E) => ResultR<R2, U, F>) =>
   <R1, T>(rr: ResultR<R1, T, E>): ResultR<R1 & R2, T | U, F> =>
   (r) =>
     rr(r).orElse((e) => f(e)(r));
 
+/**
+ * Eliminates a `ResultR` into a single value by handling both branches.
+ *
+ * @remarks
+ * Unlike the other combinators, `match` does not return a `ResultR` — it
+ * collapses the chain into a plain value. Both branch functions can return
+ * the same type, or different types that get unioned.
+ *
+ * The result is still a function of the environment `R`, so calling it
+ * requires providing `R` directly (or pulling it via {@link provide}).
+ *
+ * @typeParam T - The success type.
+ * @typeParam E - The error type.
+ * @typeParam A - The result type of the `Ok` branch.
+ * @typeParam B - The result type of the `Err` branch (defaults to `A`).
+ *
+ * @param okFn - Handler for the success branch.
+ * @param errFn - Handler for the error branch.
+ *
+ * @example
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { match } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const rendered = pipe(
+ *   okR<number>(42),
+ *   match(
+ *     (n) => `got ${n}`,
+ *     (e: never) => `error: ${String(e)}`,
+ *   ),
+ * );
+ *
+ * rendered(undefined); // 'got 42'
+ * ```
+ *
+ * @see {@link matchAsync}
+ */
 export const match =
   <T, E, A, B = A>(okFn: (t: T) => A, errFn: (e: E) => B) =>
   <R>(rr: ResultR<R, T, E>) =>
   (r: R): A | B =>
     rr(r).match(okFn, errFn);
 
+/**
+ * Runs a side effect with the success value, propagating the value unchanged.
+ *
+ * @remarks
+ * Pass-through combinator for logging, telemetry, or any other observe-only
+ * step. The callback's return value is discarded; the chain continues with
+ * the original `T`. The callback is not invoked when the chain is in `Err`.
+ *
+ * @typeParam T - The success type (preserved through the step).
+ *
+ * @param f - Side-effecting callback receiving the success value.
+ *
+ * @example
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andTee } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const traced = pipe(
+ *   okR<number>(2),
+ *   andTee((n) => console.log('saw', n)),
+ * );
+ *
+ * traced(undefined); // logs 'saw 2', returns Ok(2)
+ * ```
+ *
+ * @see {@link orTee}
+ * @see {@link andThrough} for a tee that can itself fail.
+ * @see {@link andTeeAsync}
+ */
 export const andTee =
   <T>(f: (t: T) => unknown) =>
   <R, E>(rr: ResultR<R, T, E>): ResultR<R, T, E> =>
   (r) =>
     rr(r).andTee(f);
 
+/**
+ * Runs a side effect with the error value, propagating the error unchanged.
+ *
+ * @remarks
+ * Error-channel mirror of {@link andTee}. Useful for logging failures without
+ * altering the error type or recovering from it.
+ *
+ * @typeParam E - The error type (preserved through the step).
+ *
+ * @param f - Side-effecting callback receiving the error value.
+ *
+ * @example
+ * ```ts
+ * import { errR } from '@konker.dev/neverthrow-r/constructors';
+ * import { orTee } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const logged = pipe(
+ *   errR<string>('boom'),
+ *   orTee((e) => console.error('failed:', e)),
+ * );
+ *
+ * logged(undefined); // logs 'failed: boom', returns Err('boom')
+ * ```
+ *
+ * @see {@link andTee}
+ * @see {@link orTeeAsync}
+ */
 export const orTee =
   <E>(f: (e: E) => unknown) =>
   <R, T>(rr: ResultR<R, T, E>): ResultR<R, T, E> =>
   (r) =>
     rr(r).orTee(f);
 
+/**
+ * Runs a fallible step for its side effect, then propagates the original
+ * success value if the step succeeds.
+ *
+ * @remarks
+ * Like {@link andTee}, but the tee step is itself a `ResultR` that can fail.
+ * If the tee step returns `Err`, that error replaces the chain's value; if it
+ * returns `Ok`, the chain continues with the *original* success value (the
+ * tee's success value is discarded).
+ *
+ * Common shape: validate a value via a fallible check without losing the
+ * value itself.
+ *
+ * @typeParam T - The success type (preserved through the step on success).
+ * @typeParam R2 - The tee's requirements (intersected into the chain).
+ * @typeParam F - The tee's error type (unioned with the chain's).
+ *
+ * @param f - Function from the success value to a `ResultR` whose value is
+ *   ignored on success.
+ *
+ * @example
+ * ```ts
+ * import { errR, okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andThrough } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ *
+ * const validated = pipe(
+ *   okR<number>(2),
+ *   andThrough((n) => (n > 0 ? okR<unknown>(undefined) : errR<string>('non-positive'))),
+ * );
+ *
+ * validated(undefined); // Ok(2)
+ * ```
+ *
+ * @see {@link andTee} for the infallible version.
+ * @see {@link andThroughAsync}
+ */
 export const andThrough =
   <T, R2, F>(f: (t: T) => ResultR<R2, unknown, F>) =>
   <R1, E>(rr: ResultR<R1, T, E>): ResultR<R1 & R2, T, E | F> =>

--- a/packages/neverthrow-r/src/types.ts
+++ b/packages/neverthrow-r/src/types.ts
@@ -1,22 +1,174 @@
 /**
- * Core type aliases for the Reader-function layer: `ResultR<R, T, E>` is
- * `(r: R) => Result<T, E>` and `ResultAsyncR<R, T, E>` is its async sibling.
- * `R` defaults to `unknown` (no specific requirements). Also exposes the
- * `Scope` / `ExtendedScope` helpers used by do-notation and the `Simplify`
- * intersection-flattener.
+ * Type-level vocabulary for the package: the `ResultR` / `ResultAsyncR` shapes
+ * that add a *requirements* channel on top of `neverthrow`'s `Result` /
+ * `ResultAsync`, plus the helper types (`Scope`, `ExtendedScope`, `Simplify`)
+ * used by do-notation and intersection flattening.
+ *
+ * @remarks
+ * Most users only need {@link ResultR} and {@link ResultAsyncR}. The remaining
+ * exports are surfaced because the do-notation helpers (`bindR`, `bindAsyncR`)
+ * expose them in their return types, so consumers may encounter them in
+ * inferred types.
+ *
+ * Every operator across the package — sync, async, bridges, do — preserves the
+ * R/T/E shape and **intersects** the `R` channel across composed steps
+ * (`R1 & R2`), so requirements accumulate as a chain is built.
+ *
+ * @example
+ * Lift a value, transform it, accumulate requirements, then provide them:
+ *
+ * ```ts
+ * import { okR } from '@konker.dev/neverthrow-r/constructors';
+ * import { andThen, map } from '@konker.dev/neverthrow-r/sync';
+ * import { pipe } from '@konker.dev/neverthrow-r/pipe';
+ * import { provide } from '@konker.dev/neverthrow-r/provide';
+ * import type { ResultR } from '@konker.dev/neverthrow-r/types';
+ *
+ * type WithMultiplier = { multiplier: number };
+ *
+ * const scaled = (n: number): ResultR<WithMultiplier, number, never> =>
+ *   (r) => okR<number>(n * r.multiplier)(undefined);
+ *
+ * const program = pipe(
+ *   okR<number>(2),
+ *   map((n) => n + 1),
+ *   andThen(scaled),
+ * );
+ *
+ * provide(program, { multiplier: 10 }); // Ok(30)
+ * ```
  *
  * @module
  */
 
 import type { Result, ResultAsync } from 'neverthrow';
 
+/**
+ * A `Result<T, E>` that requires an environment `R` to produce.
+ *
+ * @remarks
+ * `ResultR<R, T, E>` is structurally `(r: R) => Result<T, E>`. The `R` channel
+ * is the third dimension this package adds on top of `neverthrow`: it makes
+ * dependencies (database handles, config, clocks, …) explicit in the type
+ * rather than implicit in the closure.
+ *
+ * Use `unknown` for `R` when no environment is required (most often via the
+ * default on constructors like {@link okR}).
+ *
+ * Composition operators in {@link sync} and {@link do} intersect `R` across
+ * steps, so `R1 & R2 & R3` falls out of `andThen`-style chains automatically.
+ *
+ * @typeParam R - The requirements (environment) the value depends on.
+ * @typeParam T - The success type.
+ * @typeParam E - The error type.
+ *
+ * @example
+ * ```ts
+ * import type { ResultR } from '@konker.dev/neverthrow-r/types';
+ * import { ok } from 'neverthrow';
+ *
+ * type Deps = { now: () => Date };
+ *
+ * const currentYear: ResultR<Deps, number, never> =
+ *   (r) => ok(r.now().getFullYear());
+ * ```
+ *
+ * @see {@link ResultAsyncR} for the async sibling.
+ * @see {@link provide} for supplying the environment.
+ */
 export type ResultR<R, T, E> = (r: R) => Result<T, E>;
+
+/**
+ * A `ResultAsync<T, E>` that requires an environment `R` to produce.
+ *
+ * @remarks
+ * The async sibling of {@link ResultR}. Structurally `(r: R) => ResultAsync<T, E>`.
+ * Combine sync and async values in one pipeline via the {@link bridges} module.
+ *
+ * @typeParam R - The requirements (environment) the value depends on.
+ * @typeParam T - The success type.
+ * @typeParam E - The error type.
+ *
+ * @example
+ * ```ts
+ * import type { ResultAsyncR } from '@konker.dev/neverthrow-r/types';
+ * import { okAsync } from 'neverthrow';
+ *
+ * type Deps = { fetch: (url: string) => Promise<unknown> };
+ *
+ * const fetchJson: (url: string) => ResultAsyncR<Deps, unknown, never> =
+ *   (url) => (r) => okAsync(undefined).map(() => r.fetch(url));
+ * ```
+ *
+ * @see {@link ResultR} for the sync version.
+ */
 export type ResultAsyncR<R, T, E> = (r: R) => ResultAsync<T, E>;
 
+/**
+ * Flattens an intersection type into a single record so it renders nicely in
+ * inferred type displays and tooltips.
+ *
+ * @remarks
+ * Used internally where a chain has accumulated `R1 & R2 & R3 & …` and a
+ * cleaner display is desired (e.g. {@link provideSome}'s return type). Has no
+ * runtime effect.
+ *
+ * @typeParam T - The type to flatten.
+ *
+ * @example
+ * ```ts
+ * import type { Simplify } from '@konker.dev/neverthrow-r/types';
+ *
+ * type A = { a: number };
+ * type B = { b: string };
+ * type Combined = Simplify<A & B>; // { a: number; b: string }
+ * ```
+ */
 export type Simplify<T> = { [K in keyof T]: T[K] } & {};
 
+/**
+ * A record-shaped scope keyed by string field names, used by do-notation to
+ * accumulate intermediate values across a chain of `bindR` / `bindAsyncR`
+ * steps.
+ *
+ * @typeParam Keys - The union of string keys currently in the scope.
+ *
+ * @example
+ * ```ts
+ * import type { Scope } from '@konker.dev/neverthrow-r/types';
+ *
+ * type S = Scope<'user' | 'config'>;
+ * // { user: unknown; config: unknown }
+ * ```
+ *
+ * @see {@link ExtendedScope} for the type-level "add a field" operation.
+ */
 export type Scope<Keys extends string> = Record<Keys, unknown>;
 
+/**
+ * Adds a typed field `N: A` to an existing scope `S`, preserving the existing
+ * fields' types. Distributive over unions in `S`.
+ *
+ * @remarks
+ * This is the type-level operation behind {@link bindR}: it computes the
+ * record shape *after* a new field has been bound, with the new field's type
+ * `A` slotted in and existing fields untouched.
+ *
+ * @typeParam S - The existing scope record.
+ * @typeParam N - The string-literal name of the field being added.
+ * @typeParam A - The type of the newly bound value.
+ *
+ * @example
+ * ```ts
+ * import type { ExtendedScope } from '@konker.dev/neverthrow-r/types';
+ *
+ * type S0 = { user: { id: number } };
+ * type S1 = ExtendedScope<S0, 'role', 'admin' | 'guest'>;
+ * // { user: { id: number }; role: 'admin' | 'guest' }
+ * ```
+ *
+ * @see {@link bindR}
+ */
 export type ExtendedScope<S extends object, N extends string, A> = S extends unknown
   ? {
       [K in keyof S | N]: K extends N ? A : K extends keyof S ? S[K] : never;

--- a/packages/neverthrow-r/tsconfig.examples.json
+++ b/packages/neverthrow-r/tsconfig.examples.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["es2023", "dom"],
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "baseUrl": ".",
+    "paths": {
+      "@konker.dev/neverthrow-r": ["./src/index.ts"],
+      "@konker.dev/neverthrow-r/*": ["./src/*.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", ".examples-check/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist", "docs", "node_modules"]
+}

--- a/packages/neverthrow-r/typedoc.json
+++ b/packages/neverthrow-r/typedoc.json
@@ -19,7 +19,7 @@
   "excludeInternal": true,
   "excludePrivate": true,
   "intentionallyNotExported": ["UnaryFn"],
-  "readme": "none",
+  "readme": "./docs/reference-readme.md",
   "hideGenerator": true,
   "githubPages": false,
   "gitRevision": "main"


### PR DESCRIPTION
Expands every public symbol in @konker.dev/neverthrow-r with concept-first module narratives, per-symbol @remarks, cross-links, and type-checked @example blocks. Adds a hand-written reference landing page wired through TypeDoc, plus a custom `examples-check` script that extracts every JSDoc fence and compiles it under a dedicated tsconfig — wired into `ci` alongside `generated-docs-check`. Closes KDV-176.